### PR TITLE
Add hack for defsketch class initarg

### DIFF
--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -135,7 +135,7 @@ all slot names."
 	 (slots (mapcar #'car slot-bindings))
 	 (initforms (mapcar #'(lambda (binding)
 				`(,(car binding)
-                                  :initarg ,(alexandria:make-keyword (string-upcase (symbol-name (car binding))))
+                                   :initarg ,(alexandria:make-keyword (car binding))
 				   :initform ,(cadr binding)
 				   :accessor ,(car binding)))
 			    slot-bindings)))

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -135,6 +135,7 @@ all slot names."
 	 (slots (mapcar #'car slot-bindings))
 	 (initforms (mapcar #'(lambda (binding)
 				`(,(car binding)
+                                  :initarg ,(alexandria:make-keyword (string-upcase (symbol-name (car binding))))
 				   :initform ,(cadr binding)
 				   :accessor ,(car binding)))
 			    slot-bindings)))


### PR DESCRIPTION
I am far from sure if this is the best way to do this, but this
successfully allows you to pass in a value for the user defined slots at
make-instance time instead of defsketch time.