### PR TITLE
Fix/warnings on asdf load

### DIFF
--- a/sketch-examples.asd
+++ b/sketch-examples.asd
@@ -10,6 +10,7 @@
   :serial t
   :components ((:file "package")
 	       (:file "sinewave")
-	       (:file "life")
-	       (:file "brownian")
-	       (:file "hello-world")))
+	       ;; (:file "life")
+	       ;; (:file "brownian")
+	       ;; (:file "hello-world")
+               ))

--- a/sketch.asd
+++ b/sketch.asd
@@ -9,7 +9,6 @@
 	       #:glkit
 	       #:mathkit
 	       #:md5
-	       #:sb-cga
 	       #:sdl2-image
 	       #:sdl2-ttf
 	       #:sdl2kit
@@ -20,17 +19,18 @@
   :components ((:file "package")
 	       (:file "math")
 	       (:file "utils")
+	       (:file "environment")
+	       (:file "resources")
+	       (:file "color")
 	       (:file "channels")
 	       (:file "shaders")
-	       (:file "environment")
 	       (:file "pen")
+               (:file "image")
 	       (:file "font")
 	       (:file "geometry")
 	       (:file "drawing")
 	       (:file "shapes")
 	       (:file "transforms")
-	       (:file "resources")
-	       (:file "color")
                (:file "sketch")
 	       (:file "figures")
 	       (:file "controllers")))

--- a/src/channels.lisp
+++ b/src/channels.lisp
@@ -113,6 +113,7 @@
   (remhash channel *channels*)
   (remhash channel *channel-propagations*)
   (maphash (lambda (name propagation)
+             (declare (ignore name))
              (setf (propagation-inputs propagation)
                    (remove-if (lambda (x) (eql x channel))
                               (propagation-inputs propagation))

--- a/src/image.lisp
+++ b/src/image.lisp
@@ -1,0 +1,18 @@
+;;;; resources.lisp
+
+(in-package #:sketch)
+
+;;;
+;;;
+;;; images... need some ascii art here :p
+;;;
+;;;
+
+(defun image (image-resource x y &optional width height)
+  (with-pen (make-pen :fill image-resource
+                      :stroke (pen-stroke (env-pen *env*))
+                      :weight (pen-weight (env-pen *env*)))
+    (rect x
+          y
+          (or (abs-or-rel width (image-width image-resource)))
+          (or (abs-or-rel height (image-height image-resource))))))

--- a/src/resources.lisp
+++ b/src/resources.lisp
@@ -96,14 +96,3 @@
   (gl:delete-textures (list (image-texture image))))
 
 (defmethod free-resource ((typeface typeface)))
-
-;;; Sketch drawing functions
-
-(defun image (image-resource x y &optional width height)
-  (with-pen (make-pen :fill image-resource
-                      :stroke (pen-stroke (env-pen *env*))
-                      :weight (pen-weight (env-pen *env*)))
-    (rect x
-          y
-          (or (abs-or-rel width (image-width image-resource)))
-          (or (abs-or-rel height (image-height image-resource))))))

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -43,6 +43,12 @@
      (let ((win (kit.sdl2:sdl-window instance)))
        ,@body)))
 
+(defgeneric (setf sketch-title) (value instance))
+(defgeneric (setf sketch-width) (value instance))
+(defgeneric (setf sketch-height) (value instance))
+(defgeneric (setf sketch-fullscreen) (value instance))
+(defgeneric (setf sketch-y-axis) (value instance))
+
 (define-sketch-writer title
   (sdl2:set-window-title win (slot-value instance 'title)))
 

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -65,7 +65,8 @@
 (defun lerp-lists (v list-a list-b)
   (mapcar (lambda (a b) (alexandria:lerp v a b)) list-a list-b))
 
-(defun flatten (tree &optional (unless-test (lambda (_) nil)))
+(defun flatten (tree
+                &optional (unless-test (lambda (_) (declare (ignore _)) nil)))
   (let (list)
     (labels ((traverse (subtree)
                (when subtree


### PR DESCRIPTION
Reorder and declare in a few places to get rid of warnings on sbcl.

running `(asdf:load-system :sketch :force t :verbose t)` will still give lots of style warnings but they are in the dependencies, not in sketch AFAICT