### PR TITLE
Fix typo curve-step -> curve-steps

### DIFF
--- a/README.org
+++ b/README.org
@@ -366,7 +366,7 @@ We can also change the thickness of the lines and shapes that we draw by changin
   (defsketch curve-test
      ((title "Curve-steps"))
     (dotimes (i 99)
-      (with-pen (make-pen :stroke +red+ :curve-step (+ i 1)) ; as curve-step increases, curve becomes "smoother"
+      (with-pen (make-pen :stroke +red+ :curve-steps (+ i 1)) ; as curve-step increases, curve becomes "smoother"
         (bezier 0 400 100 100 300 100 400 400))))
 #+END_SRC
 


### PR DESCRIPTION
the keyword argument :CURVE-STEP is not one of #(:FILL :STROKE :WEIGHT :CURVE-STEPS), which are recognized by the current global definition of MAKE-PEN