### PR TITLE
Various font/image bugfixes

### DIFF
--- a/src/font.lisp
+++ b/src/font.lisp
@@ -61,13 +61,11 @@
     (destructuring-bind (r g b a) (color-rgba-255 (font-color font))
       (make-image-from-surface (sdl2-ttf:render-utf8-blended
                                 (typeface-pointer typeface)
-                                line r g b a)
+                                (if (string= line "") " " line) r g b a)
                                :free-surface nil))))
 
 (defun text (text-string x y &optional width height)
-  (let* ((font (env-font *env*))
-         (typeface (and font (load-resource (typeface-filename (font-face font))
-                                            :size (font-size font)))))
+  (let* ((font (env-font *env*)))
     (when (and font (> (length text-string) 0))
       (with-pen (make-pen :stroke nil)
         (let* ((top 0)

--- a/src/resources.lisp
+++ b/src/resources.lisp
@@ -81,6 +81,7 @@
   (let ((texture (car (gl:gen-textures 1))))
     (gl:bind-texture :texture-2d texture)
     (gl:tex-parameter :texture-2d :texture-min-filter :linear)
+    (gl:pixel-store :unpack-row-length (/ (sdl2:surface-pitch surface) 4))
     (gl:tex-image-2d :texture-2d 0 :rgba
                      (sdl2:surface-width surface)
                      (sdl2:surface-height surface)


### PR DESCRIPTION
Use the sdl2 surface pitch when generating an OpenGL image
This should fix https://github.com/vydd/sketch/issues/51

I ended up seeing the same issue, and it turned out that the SDL surface pitch generated from sdl2-ttf was not being taken into account when sending the pixel data to OpenGL.  Essentially there are sometimes gaps in the data because the sdl2 surface gets aligned to a power-of-two row length, instead of the number of bytes in each row.

I tested locally and it fixed the issue.

If the pitch ends up being the same as the width of the surface in pixels, this should still work fine.

2nd commit:
This should fix https://github.com/vydd/sketch/issues/32

 Fix handling of different byte orders on SDL_Surface when converting to GL texture

SDL_ttf is generating argb32 images, while loaded images are rgba to start with.
With this change, we'll now convert the SDL surface to rgba32 if it's not that
format already.

Note that previously text was working with :bgra, which is :argb in big-endian
format. That's why I went with rgba32 vs rgba8888, which would have the wrong
endianness. I tested all of this out to come to that conclustion.

Tested this change and both text and images are loading with the proper colors
now.

3rd commit:
Removed unused 'typeface' binding

Convert empty text lines to a single space since sdl2-ttf throws an error on an
  empty string.  Converted to space instead of removing to keep line height
  formatting.  This was causing issues with type errors from SBCL that ended up
  having empty lines on them.  The error wouldn't display.