### PR TITLE
Updated to readme link to an existing repository

### DIFF
--- a/README.org
+++ b/README.org
@@ -387,7 +387,7 @@ TODO
 
 ** Made with Sketch
 - [[https://vydd.itch.io/qelt][QELT]]
-- [[https://bitbucket.org/sjl/coding-math][sjl's implementation of coding math videos]]
+- [[https://github.com/sjl/coding-math][sjl's implementation of coding math videos]]
 - [[http://git.axity.net/axion/crawler2][Visual examples for axion's crawler2 library]]
 
 ** FAQ


### PR DESCRIPTION
The existing link to sjl's implementation of coding math videos seems to be dead. As far as I can tell this looks to be it's new home