### PR TITLE
Adds define-start-function

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -48,6 +48,7 @@
            :degrees
 
            ;; Utils
+           :define-start-function
            :relative-path
 
            ;; Colors

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -11,11 +11,13 @@
 (defparameter *build* nil)
 
 (defmacro define-start-function (name sketch (&rest args))
-  `(defun ,name ()
-     (sdl2:make-this-thread-main
-      (lambda ()
-        (let ((*build* t))
-          (make-instance ',sketch ,@args))))))
+  `(defun ,name (&optional live)
+     (if live
+         (make-instance ',sketch ,@args)
+         (sdl2:make-this-thread-main
+          (lambda ()
+            (let ((*build* t))
+              (make-instance ',sketch ,@args)))))))
 
 (defun pad-list (list pad length)
   (if (>= (length list) length)

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -10,6 +10,13 @@
 
 (defparameter *build* nil)
 
+(defmacro define-start-function (name sketch (&rest args))
+  `(defun ,name ()
+     (sdl2:make-this-thread-main
+      (lambda ()
+        (let ((*build* t))
+          (make-instance ',sketch ,@args))))))
+
 (defun pad-list (list pad length)
   (if (>= (length list) length)
       list


### PR DESCRIPTION
After thinking about https://github.com/vydd/sketch/issues/58 I have come up with `define-start-function` which can be used like this:
```common-lisp
(define-start-function start game (:resizable t :title "Sketchy game"))
```
Opening & closing other libraries (like `sdl2-mixer`):
```common-lisp
(defmethod setup ((game game) &key &allow-other-keys)
  (sdl2-mixer:init-sound))

(defmethod kit.sdl2:close-window :before ((game game))
  (sdl2-mixer:quit-sound))
```
Under `sbcl` it can be saved to executable:
```common-lisp
(defun)
(save-lisp-and-die "game.bin" :toplevel #'start :executable t)
```
Or it can be used with asdf:make (specify in `asdf:defsystem`).
With `deploy`:
```common-lisp
(asdf:defsystem "game"
  ; system definition
  :defsystem-depends-on (:deploy)
  :build-operation #-darwin "deploy-op" #+darwin "osx-app-deploy-op"
  :build-pathname "game"
  :entry-point "game:start")
```
Or without:
```common-lisp
(asdf:defsystem "game"
  ; system definition
  :build-operation "program-op"
  :build-pathname "game"
  :entry-point "game:start")
```
And a simple `build.lisp` script:
```common-lisp
(ql:quickload '(:deploy :game))
;; with `deploy`: it ships foreign dependencies, but you should not ship OpenGL
(deploy:define-library cl-opengl-bindings::opengl :dont-deploy t)
(asdf:make :game)
(quit)
```
---
I'm not sure that this is a flexible way to define start function: this macro doesn't have a body and naming is not good as well.
Probably `make-executable` could be added.

Probable macro should be renamed: it shadows `kit.sdl2:define-start-function` right now.