### PR TITLE
Default window size

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -30,6 +30,9 @@
            :copy-pixels
            :y-axis
 
+           :*default-width*
+           :*default-height*
+
            ;; Math
            :clamp-1
            :normalize

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -21,11 +21,16 @@
 (defparameter *sketch* nil
   "The current sketch instance.")
 
+(defparameter *default-width* 400
+  "The default width of sketch window")
+(defparameter *default-height* 400
+  "The default height of sketch window")
+
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defparameter *default-slots*
     '((title :initform "Sketch" :reader sketch-title :initarg :title)
-      (width :initform 400 :reader sketch-width :initarg :width)
-      (height :initform 400 :reader sketch-height :initarg :height)
+      (width :initform *default-width* :reader sketch-width :initarg :width)
+      (height :initform *default-height* :reader sketch-height :initarg :height)
       (fullscreen :initform nil :reader sketch-fullscreen :initarg :fullscreen)
       (copy-pixels :initform nil :accessor sketch-copy-pixels :initarg :copy-pixels)
       (y-axis :initform :down :reader sketch-y-axis :initarg :y-axis))))


### PR DESCRIPTION
Completes https://github.com/vydd/sketch/issues/25.
Fixes https://github.com/vydd/sketch/issues/69.

It adds `:default-initargs` to the class definition generated by `defsketch` and uses them to set `:w` and `:h` initargs in the `initialize-instance :around` method. Those are used in `sdl2:create-window` by `kit.sdl2`.

Thus the window is
1. is not resized immediately after its creation (which probably is the problem with https://github.com/vydd/sketch/issues/69);
2. centered during the creation (unless `:x` or `:y` are specified).