### PR TITLE
Gleefre/move complex parts of defsketch

### DIFF
--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -277,6 +277,10 @@ used for drawing, 60fps.")
 
 ;;; DEFSKETCH macro
 
+(defun sketch-class-definition (sketch-name bindings)
+  `(defclass ,sketch-name (sketch)
+     ,(sketch-bindings-to-slots `,sketch-name bindings)))
+
 (defun prepare-method-definition (sketch-name bindings default-not-overridden)
   `(defmethod prepare ((*sketch* ,sketch-name) &rest initargs &key &allow-other-keys)
      (declare (ignorable initargs))
@@ -309,8 +313,7 @@ used for drawing, 60fps.")
           (remove-if (lambda (x) (find x bindings :key #'car))
                      (mapcar #'car *default-slots*))))
     `(progn
-       (defclass ,sketch-name (sketch)
-         ,(sketch-bindings-to-slots `,sketch-name bindings))
+       ,(sketch-class-definition sketch-name bindings)
 
        ,@(remove-if-not #'identity (make-channel-observers sketch-name bindings))
 

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -277,6 +277,13 @@ used for drawing, 60fps.")
 
 ;;; DEFSKETCH macro
 
+(defun draw-method-definition (sketch-name bindings body)
+  `(defmethod draw ((*sketch* ,sketch-name) &key &allow-other-keys)
+     (with-accessors ,(mapcar (lambda (x) (list (car x) (intern-accessor (car x))))
+                       *default-slots*) *sketch*
+       (with-slots ,(mapcar #'car bindings) *sketch*
+         ,@body))))
+
 (defmacro defsketch (sketch-name bindings &body body)
   (let ((default-not-overridden
           (remove-if (lambda (x) (find x bindings :key #'car))
@@ -306,11 +313,7 @@ used for drawing, 60fps.")
                   (setf (env-y-axis-sgn (slot-value *sketch* '%env))
                         (if (eq (slot-value *sketch* 'y-axis) :down) +1 -1)))
 
-       (defmethod draw ((*sketch* ,sketch-name) &key &allow-other-keys)
-         (with-accessors ,(mapcar (lambda (x) (list (car x) (intern-accessor (car x))))
-                           *default-slots*) *sketch*
-           (with-slots ,(mapcar #'car bindings) *sketch*
-             ,@body)))
+       ,(draw-method-definition sketch-name bindings body)
 
        (make-instances-obsolete ',sketch-name)
 

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -314,13 +314,8 @@ used for drawing, 60fps.")
                      (mapcar #'car *default-slots*))))
     `(progn
        ,(sketch-class-definition sketch-name bindings)
-
        ,@(remove-if-not #'identity (make-channel-observers sketch-name bindings))
-
        ,(prepare-method-definition sketch-name bindings default-not-overridden)
-
        ,(draw-method-definition sketch-name bindings body)
-
        (make-instances-obsolete ',sketch-name)
-
        (find-class ',sketch-name))))


### PR DESCRIPTION
Moves parts of defsketch to separate functions. Makes it easier to read the definition and track which parameters of defsketch these parts depend on. 

> I'm finding some utility in having it represent a rough shape of what's generated - defclass, prepare, draw.

Originally part of #87.