### PR TITLE
Cut image surface on load

### DIFF
--- a/src/resources.lisp
+++ b/src/resources.lisp
@@ -107,10 +107,25 @@
 (defmethod load-typed-resource (filename (type (eql :image))
                                 &key (min-filter :linear)
                                      (mag-filter :linear)
+				     (x nil)
+				     (y nil)
+				     (w nil)
+				     (h nil)
                                 &allow-other-keys)
-  (make-image-from-surface (sdl2-image:load-image filename)
-                           :min-filter min-filter
-                           :mag-filter mag-filter))
+  (let ((surface (sdl2-image:load-image filename)))
+    (make-image-from-surface (cut-surface surface x y w h)
+			     :min-filter min-filter
+			     :mag-filter mag-filter)))
+
+(defun cut-surface (surface x y w h)
+  (if (and x y w h)
+      (let ((src-rect (sdl2:make-rect x y w h))
+	    (dst-rect (sdl2:make-rect 0 0 w h))
+	    (dst-surface (sdl2:create-rgb-surface w h 32)))
+	(sdl2:blit-surface surface src-rect dst-surface dst-rect)
+	(sdl2:free-surface surface)
+	dst-surface)
+      surface))
 
 (defmethod load-typed-resource (filename (type (eql :typeface))
                                 &key (size 18) &allow-other-keys)


### PR DESCRIPTION
Adds 4 optional params (x y w h) when loading image resources, to put only a part of the image into the texture.

This is how to tile a part of an image:

```lisp
(defsketch tile
    ((width 400) (height 400))
  (let ((res (load-resource "100x100.png" :x 0 :y 0 :w 50 :h 50)))
    (with-pen (make-pen :fill (crop res 0 0 100 100))
      (rect 0 0 400 400))))
```

Here, only the upper left 50x50 part of the image is loaded. As `crop` (unintuivitely?) tiles the image when width or height are larger than the ones of the image, the intended effect is achieved.