### PR TITLE
Clear SDL error when setting swap interval is not supported

### DIFF
--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -58,8 +58,10 @@
 (defun initialize-gl (w)
   (with-slots ((env %env) width height) w
     (handler-case (sdl2:gl-set-swap-interval 1)
+      ;; Some OpenGL drivers do not allow to control swapping.
+      ;; In this case SDL2 sets an error that needs to be cleared.
       (sdl2::sdl-rc-error (e)
-        (warn "Can't set swap interval: ~A" (slot-value e 'sdl2::string))
+        (warn "VSYNC was not enabled; frame rate was not restricted to 60fps.~%  ~A" e)
         (sdl2-ffi.functions:sdl-clear-error)))
     (setf (kit.sdl2:idle-render w) t)
     (gl:viewport 0 0 width height)

--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -57,7 +57,10 @@
 
 (defun initialize-gl (w)
   (with-slots ((env %env) width height) w
-    (sdl2:gl-set-swap-interval 1)
+    (handler-case (sdl2:gl-set-swap-interval 1)
+      (sdl2::sdl-rc-error (e)
+        (warn "Can't set swap interval: ~A" (slot-value e 'sdl2::string))
+        (sdl2-ffi.functions:sdl-clear-error)))
     (setf (kit.sdl2:idle-render w) t)
     (gl:viewport 0 0 width height)
     (gl:enable :blend :line-smooth :polygon-smooth)


### PR DESCRIPTION
Fixes https://github.com/vydd/sketch/issues/40. Note that a warning will be signaled if setting the swap interval is not supported.

Also note that in this case vsync will no longer be activated and FPS will not be limited to 60 anymore.