### PR TITLE
Fix free-resource method for NIL

### DIFF
--- a/src/resources.lisp
+++ b/src/resources.lisp
@@ -140,9 +140,7 @@
 
 (defgeneric free-resource (resource))
 
-(defmethod free-resource :around (resource)
-  (when resource
-    (call-next-method)))
+(defmethod free-resource ((resource (eql nil))))
 
 (defmethod free-resource ((image image))
   (gl:delete-textures (list (image-texture image))))


### PR DESCRIPTION
Since there is no primary method defined for `free-resource` calling it on `NIL` will signal an error, which doesn't seem to be desired:
```lisp
* (sketch::free-resource nil)

There is no primary method for the generic function
  #<STANDARD-GENERIC-FUNCTION SKETCH::FREE-RESOURCE (3)>
when called with arguments
  (NIL).
   [Condition of type SB-PCL::NO-PRIMARY-METHOD-ERROR]
See also:
  Common Lisp Hyperspec, 7.6.6.2 [:section]
```