### PR TITLE
Gleefre/free font surfaces manually

### DIFF
--- a/sketch.asd
+++ b/sketch.asd
@@ -16,6 +16,7 @@
                #:sdl2kit
                #:split-sequence
                #:static-vectors
+               #:trivial-garbage
                #:zpng)
   :pathname "src"
   :serial t

--- a/src/font.lisp
+++ b/src/font.lisp
@@ -63,7 +63,7 @@
       (make-image-from-surface (sdl2-ttf:render-utf8-blended
                                 (typeface-pointer typeface)
                                 line r g b a)
-                               :free-surface nil))))
+                               :free-surface :font))))
 
 (defun text (text-string x y &optional width height)
   (let* ((font (env-font *env*)))

--- a/src/resources.lisp
+++ b/src/resources.lisp
@@ -101,7 +101,10 @@
                                 :height (sdl2:surface-height rgba-surface)
                                 :texture texture)))
       (unless (eq rgba-surface surface) (sdl2:free-surface rgba-surface))
-      (when free-surface (sdl2:free-surface surface))
+      (when free-surface
+        (when (eq free-surface :font)
+          (tg:cancel-finalization surface))
+        (sdl2:free-surface surface))
       image)))
 
 (defmethod load-typed-resource (filename (type (eql :image))


### PR DESCRIPTION
Leaving it to finalizers (which cl-sdl2-ttf does) may lead to various bugs (SDL2_TTF is not thread-safe while finalizers can be executed at any point; or they might not be called at all creating a memory leak.)

(See also https://github.com/Failproofshark/cl-sdl2-ttf/issues/22)