### PR TITLE
Optimize COPY-BUFFER (also gets rid of warnings)

### DIFF
--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -81,10 +81,13 @@ but may be considered unique for all practical purposes."
   (coerce x 'single-float))
 
 (defun copy-buffer (src dst length &key (src-offset 0) (dst-offset 0))
-  (declare (optimize (speed 3) (debug 0)))
-  (loop for i from 0 below length
-     do (setf (cffi:mem-aref dst :uint8 (+ i src-offset))
-              (cffi:mem-aref src :uint8 (+ i dst-offset)))))
+  (declare (optimize (speed 3) (debug 0))
+           (type fixnum length src-offset dst-offset))
+  (loop with src* = (cffi:mem-aptr src :uint8 src-offset)
+        with dst* = (cffi:mem-aptr dst :uint8 dst-offset)
+        for i below length
+        do (setf (cffi:mem-aref dst* :uint8 i)
+                 (cffi:mem-aref src* :uint8 i))))
 
 (defun relative-path (path &optional (system 'sketch))
   (if *build*


### PR DESCRIPTION
COPY-BUFFER is only used when drawing a figure.
SRC-OFFSET and DST-OFFSET are not used, so it is safe to assume they are fixnums (they are always 0). LENGTH is the length of the static-vector which holds the cached buffer data. By ANSI it is bounded by the ARRAY-DIMENSION-LIMIT which is guaranteed to be a fixnum, so LENGTH is a fixnum too.

Tested that figures still work on this small example:
```lisp
(defpackage #:sketch-user
  (:use #:cl #:sketch))

(in-package #:sketch-user)

(deffigure foo
  (circle 0 10 20)
  (rect 10 20 30 40))

(defsketch bar ()
  (foo (in :mouse-x 0)
       (in :mouse-y 0)))

(make-instance 'bar)
```