### PR TITLE
Add RESIZABLE slot to the SKETCH class

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -20,6 +20,7 @@
            :sketch-width
            :sketch-height
            :sketch-fullscreen
+           :sketch-resizable
            :sketch-copy-pixels
            :sketch-y-axis
 
@@ -27,6 +28,7 @@
            :width
            :height
            :fullscreen
+           :resizable
            :copy-pixels
            :y-axis
 

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -32,6 +32,7 @@
       (width :initform *default-width* :accessor sketch-width :initarg :width)
       (height :initform *default-height* :accessor sketch-height :initarg :height)
       (fullscreen :initform nil :accessor sketch-fullscreen :initarg :fullscreen)
+      (resizable :initform nil :accessor sketch-resizable :initarg :resizable)
       (copy-pixels :initform nil :accessor sketch-copy-pixels :initarg :copy-pixels)
       (y-axis :initform :down :accessor sketch-y-axis :initarg :y-axis))))
 
@@ -61,6 +62,11 @@
 
 (define-sketch-writer fullscreen
   (sdl2:set-window-fullscreen win value))
+
+(define-sketch-writer resizable
+  (sdl2-ffi.functions:sdl-set-window-resizable
+   win
+   (if value sdl2-ffi:+true+ sdl2-ffi:+false+)))
 
 (define-sketch-writer y-axis
   (declare (ignore win))


### PR DESCRIPTION
Makes it possible to specify whether the sketch should be resizable or not by providing a binding in `defsketch`.
For example:

```lisp
(defsketch foo ((resizable t))
  (text (format nil "Resizable! Current size: ~Ax~A" width height) 0 0))
```
`foo` will be resizable by default (unless it is turned off by providing `:resizable nil` to `make-intstance`)