### PR TITLE
Usability tweaks for the canvas.

### DIFF
--- a/README.org
+++ b/README.org
@@ -523,12 +523,7 @@ The generic function =(setup instance &key &allow-other-keys)= is a hook that ge
 
 =(canvas-unlock canvas)= allows the image of the canvas to be modified again.
 
-To draw the canvas:
-
-#+BEGIN_SRC lisp
-  (with-pen (make-pen :fill (canvas-image canvas))
-    (rect 0 0 (canvas-width canvas) (canvas-height canvas)))
-#+END_SRC
+=(draw-canvas canvas &key (x 0) (y 0) (width nil) (height nil)= draws the canvas; by default, the original width and height of the canvas are used, but these can be overridden.
 
 Example: [[https://github.com/vydd/sketch/blob/master/examples/stars.lisp][stars.lisp]].
 

--- a/README.org
+++ b/README.org
@@ -523,7 +523,7 @@ The generic function =(setup instance &key &allow-other-keys)= is a hook that ge
 
 =(canvas-unlock canvas)= allows the image of the canvas to be modified again.
 
-=(draw-canvas canvas &key (x 0) (y 0) (width nil) (height nil)= draws the canvas; by default, the original width and height of the canvas are used, but these can be overridden.
+=(draw canvas &key (x 0) (y 0) (width nil) (height nil)= draws the canvas; by default, the original width and height of the canvas are used, but these can be overridden.
 
 Example: [[https://github.com/vydd/sketch/blob/master/examples/stars.lisp][stars.lisp]].
 

--- a/src/canvas.lisp
+++ b/src/canvas.lisp
@@ -64,10 +64,11 @@
 (defmethod canvas-unlock ((canvas canvas))
   (setf (%canvas-locked canvas) nil))
 
-(defun draw-canvas (canvas &key (x 0) (y 0)
-                             (width nil) (height nil)
-                             (min-filter :linear)
-                             (mag-filter :linear))
+(defmethod draw ((canvas canvas)
+                 &key (x 0) (y 0)
+                   (width nil) (height nil)
+                   (min-filter :linear)
+                   (mag-filter :linear))
   "Draws a canvas with its top-left corner at co-ordinates X & Y. By default,
 uses the width and height that the canvas was created with, but these can be
 overwritten by parameters WIDTH and HEIGHT.
@@ -79,6 +80,7 @@ CANVAS-LOCK is being used, then MIN-FILTER and MAG-FILTER should be passed
 there instead.
 
 See: https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexParameter.xhtml"
+  ;; TODO: refactor to call the DRAW interface for images.
   (with-pen (make-pen :fill (canvas-image canvas
                                           :min-filter min-filter
                                           :mag-filter mag-filter))

--- a/src/canvas.lisp
+++ b/src/canvas.lisp
@@ -74,7 +74,10 @@ overwritten by parameters WIDTH and HEIGHT.
 
 MIN-FILTER and MAG-FILTER are used to determine pixel colours when the
 drawing area is smaller or larger, respectively, than the canvas. By default,
-the :LINEAR function is used. :NEAREST is also a common option.
+the :LINEAR function is used. :NEAREST is also a common option. Note that, if
+CANVAS-LOCK is being used, then MIN-FILTER and MAG-FILTER should be passed
+there instead.
+
 See: https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexParameter.xhtml"
   (with-pen (make-pen :fill (canvas-image canvas
                                           :min-filter min-filter

--- a/src/canvas.lisp
+++ b/src/canvas.lisp
@@ -63,3 +63,20 @@
 
 (defmethod canvas-unlock ((canvas canvas))
   (setf (%canvas-locked canvas) nil))
+
+(defun draw-canvas (canvas &key (x 0) (y 0)
+                             (width nil) (height nil)
+                             (min-filter :linear)
+                             (mag-filter :linear))
+  "Draws a canvas with its top-left corner at co-ordinates X & Y. By default,
+uses the width and height that the canvas was created with, but these can be
+overwritten by parameters WIDTH and HEIGHT.
+
+MIN-FILTER and MAG-FILTER are used to determine pixel colours when the
+drawing area is smaller or larger, respectively, than the canvas. By default,
+the :LINEAR function is used. :NEAREST is also a common option.
+See: https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexParameter.xhtml"
+  (with-pen (make-pen :fill (canvas-image canvas
+                                          :min-filter min-filter
+                                          :mag-filter mag-filter))
+    (rect x y (or width (canvas-width canvas)) (or height (canvas-height canvas)))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -146,6 +146,8 @@
            ;; Resources
            :load-resource
            :image
+           :image-width
+           :image-height
            :crop
            :with-uv-rect
            :save-png
@@ -164,4 +166,7 @@
            :canvas-image
            :canvas-lock
            :canvas-unlock
+           :canvas-width
+           :canvas-height
+           :draw-canvas
            ))


### PR DESCRIPTION
This adds a function called `(draw-canvas ...)` so that people don't need to include boilerplate code every time they want to draw a canvas. Also exports `canvas-width`, `canvas-height`, `image-width` and `image-height`, which I think are useful to have. Finally, it updates the canvas documentation. I left the "stars" example untouched in case it's helpful to see how to draw a canvas using lower-level functions.

Example:

```lisp
(defsketch test
      ((title "Canvas test")
       (size-scale 1))
    (let ((cv (make-canvas 2 2)))
      (canvas-paint cv +blue+ 0 0)
      (canvas-paint cv +red+ 0 1)
      (canvas-paint cv +green+ 1 0)
      (canvas-paint cv +white+ 1 1)
      (canvas-lock cv)
      (let ((draw-size (* size-scale 2)))
        (draw-canvas cv :width draw-size :height draw-size
                     :min-filter :linear :mag-filter :linear)))
    (setf size-scale (mod (1+ size-scale) 50)))
```

(I'm not sure how the min & mag filters are supposed to work, but even when I pass `:nearest`, it still looks like a linear interpolation between the colours).