### PR TITLE
Switch to drawing images with DRAW method.

### DIFF
--- a/README.org
+++ b/README.org
@@ -418,12 +418,13 @@ Use =(text text-string x y &optional width height)= to draw text, where =x= and 
 #+END_SRC
 
 *** Images
-First =(load-resource filename ...)= to load the image from a given file, then =(image image-resource x y &optional width height)= to draw the image with its top-left corner at =(x, y)= and with the given =width= and =height=.
+First =(load-resource filename ...)= to load the image from a given file, then =(draw image &key x y width height)= to draw the image with its top-left corner at =(x, y)= and with the given =width= and =height=. If not provided, default =(x,y)= is =(0,0)= and =width= & =height= are taken from the image.
 
 #+BEGIN_SRC lisp
   (defsketch image-test
-     ((title "Hello, image!"))
-    (image (load-resource "/path/to/img.png") 10 10 200 200))
+     ((title "Hello, image!")
+      (pic (load-resource "/path/to/img.png")))
+    (draw pic :x 10 :y 10 :width 200 :height 200))
 #+END_SRC
 
 Note that =load-resource= automatically caches the resource when it is called inside a valid sketch environment (i.e. inside the defsketch's body), so it is not inefficient to call it in every loop. It is important to release resources using =sketch::free-resource=; this is done automatically for resources in the sketch environment when the sketch window is closed. Finally, to avoid caching and to reload the resource every time, the parameter =:force-reload-p= can be passed to =load-resource=.

--- a/src/canvas.lisp
+++ b/src/canvas.lisp
@@ -66,7 +66,7 @@
 
 (defmethod draw ((canvas canvas)
                  &key (x 0) (y 0)
-                   (width nil) (height nil)
+                   width height
                    (min-filter :linear)
                    (mag-filter :linear))
   "Draws a canvas with its top-left corner at co-ordinates X & Y. By default,
@@ -80,8 +80,8 @@ CANVAS-LOCK is being used, then MIN-FILTER and MAG-FILTER should be passed
 there instead.
 
 See: https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexParameter.xhtml"
-  ;; TODO: refactor to call the DRAW interface for images.
-  (with-pen (make-pen :fill (canvas-image canvas
-                                          :min-filter min-filter
-                                          :mag-filter mag-filter))
-    (rect x y (or width (canvas-width canvas)) (or height (canvas-height canvas)))))
+  (draw (canvas-image canvas :min-filter min-filter :mag-filter mag-filter)
+        :x 0
+        :y 0
+        :width (or width (canvas-width canvas))
+        :height (or height (canvas-height canvas))))

--- a/src/image.lisp
+++ b/src/image.lisp
@@ -8,14 +8,20 @@
 ;;  | || |  | |/ ___ \ |_| | |___ ___) |
 ;; |___|_|  |_/_/   \_\____|_____|____/
 
-(defun image (image-resource x y &optional width height)
-  (with-pen (make-pen :fill image-resource
+(defmethod draw ((image image) &key (x 0) (y 0) width height)
+  "Draws an image, X and Y values are 0 by default, while WIDTH and HEIGHT
+are set to the width & height of the image if not provided."
+  (with-pen (make-pen :fill image
                       :stroke (pen-stroke (env-pen *env*))
                       :weight (pen-weight (env-pen *env*)))
        (rect x
              y
-             (or (abs-or-rel width (image-width image-resource)))
-             (or (abs-or-rel height (image-height image-resource))))))
+             (or (abs-or-rel width (image-width image)))
+             (or (abs-or-rel height (image-height image))))))
+
+(defun image (image-resource x y &optional width height)
+  "***Deprecated***, use the DRAW method."
+  (draw image-resource :x x :y y :width width :height height))
 
 (defmethod crop ((image-resource image) x y w h)
   "Generate a cropped image resource from IMAGE-RESOURCE, limiting how much of the image is drawn

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -170,5 +170,4 @@
            :canvas-unlock
            :canvas-width
            :canvas-height
-           :draw-canvas
            ))


### PR DESCRIPTION
* Adds `DRAW` method to draw images, replacing `IMAGE` function. Makes API neater. `IMAGE` is left in place for backwards-compatibility.
* Updates docs.
* Refactors `(draw canvas ...)` so that it calls `(draw image ...)`, there was shared code between them.
* Removes `DRAW-CANVAS` symbol from package export list, it's not associated with a function.