### PR TITLE
Work on resizable windows

### DIFF
--- a/sketch.asd
+++ b/sketch.asd
@@ -35,6 +35,7 @@
                (:file "image")
                (:file "shapes")
                (:file "transforms")
+               (:file "complex-transforms")
                (:file "sketch")
                (:file "figures")
                (:file "controllers")

--- a/src/complex-transforms.lisp
+++ b/src/complex-transforms.lisp
@@ -1,0 +1,46 @@
+;;;; complex-transforms.lisp
+
+(in-package #:sketch)
+
+;;; FIT, WITH-FIT
+;;; Modes were taken from GTK, see https://docs.gtk.org/gtk4/enum.ContentFit.html
+(defun fit (to-width to-height from-width from-height
+            &key (to-x 0) (to-y 0) (from-x 0) (from-y 0)
+                 (mode :contain))
+  (declare (type (member :contain :cover :scale-down :fill) mode))
+  (translate from-x from-y)
+  (ecase mode
+    ((:contain :cover :scale-down)
+     (flet ((%fit-scale (scale)
+              (let ((x-shift (/ (- from-width
+                                   (* to-width scale))
+                                2))
+                    (y-shift (/ (- from-height
+                                   (* to-height scale))
+                                2)))
+                (translate x-shift y-shift)
+                (scale scale))))
+       (%fit-scale
+        (ecase mode
+          (:contain    (min (/ from-width to-width)
+                            (/ from-height to-height)))
+          (:cover      (max (/ from-width to-width)
+                            (/ from-height to-height)))
+          (:scale-down (min (/ from-width to-width)
+                            (/ from-height to-height)
+                            1))))))
+    (:fill
+     (scale (/ from-width to-width)
+            (/ from-height to-height))))
+  (translate (- to-x) (- to-y)))
+
+(defmacro with-fit (((  to-width   to-height &optional (  to-x 0) (  to-y 0))
+                     (from-width from-height &optional (from-x 0) (from-y 0))
+                     &key (mode :contain))
+                    &body body)
+  (alexandria:once-only (to-width to-height to-x to-y from-width from-height from-x from-y mode)
+    `(with-current-matrix
+       (fit ,to-width ,to-height ,from-width ,from-height
+            :to-x ,to-x :to-y ,to-y :from-x ,from-x :from-y ,from-y
+            :mode ,mode)
+       ,@body)))

--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -51,15 +51,15 @@
     (kit.gl.shader:use-program (env-programs env) :fill-shader)))
 
 (defun initialize-view-matrix (w)
-  (with-slots ((env %env) width height y-axis %viewport-changed) w
+  (with-slots ((env %env) window-width window-height y-axis %viewport-changed) w
     (setf (env-view-matrix env) (if (eq y-axis :down)
-                                    (kit.glm:ortho-matrix 0 width height 0 -1 1)
-                                    (kit.glm:ortho-matrix 0 width 0 height -1 1))
+                                    (kit.glm:ortho-matrix 0 window-width window-height 0 -1 1)
+                                    (kit.glm:ortho-matrix 0 window-width 0 window-height -1 1))
           (env-y-axis-sgn env) (if (eq y-axis :down) +1 -1)
           %viewport-changed t)))
 
 (defun initialize-gl (w)
-  (with-slots ((env %env) width height) w
+  (with-slots ((env %env)) w
     (handler-case (sdl2:gl-set-swap-interval 1)
       ;; Some OpenGL drivers do not allow to control swapping.
       ;; In this case SDL2 sets an error that needs to be cleared.

--- a/src/image.lisp
+++ b/src/image.lisp
@@ -29,23 +29,23 @@ are set to the width & height of the image if not provided."
   (cropped-image-from-image image-resource x y w h))
 
 (defun save-png (pathname)
-  (let ((width (sketch-width *sketch*))
-        (height (sketch-height *sketch*)))
+  (let ((window-width (sketch-window-width *sketch*))
+        (window-height (sketch-window-height *sketch*)))
     (flet ((ptr (vec offset)
              (static-vectors:static-vector-pointer vec :offset offset))
            (from (row col width)
              (+ col (* row (* 4 width))))
            (to (row col width height)
              (+ col (* (- height row 1) 4 width))))
-      (static-vectors:with-static-vector (buffer (* 4 width height))
-        (%gl:read-pixels 0 0 width height :rgba :unsigned-byte (ptr buffer 0))
-        (dotimes (row (truncate height 2))
-          (dotimes (col (* 4 width))
-            (rotatef (cffi:mem-aref (ptr buffer (from row col width)) :uint8)
-                     (cffi:mem-aref (ptr buffer (to row col width height)) :uint8))))
+      (static-vectors:with-static-vector (buffer (* 4 window-width window-height))
+        (%gl:read-pixels 0 0 window-width window-height :rgba :unsigned-byte (ptr buffer 0))
+        (dotimes (row (truncate window-height 2))
+          (dotimes (col (* 4 window-width))
+            (rotatef (cffi:mem-aref (ptr buffer (from row col window-width)) :uint8)
+                     (cffi:mem-aref (ptr buffer (to row col window-width window-height)) :uint8))))
         (let ((png (make-instance 'zpng:png
-                                  :width width
-                                  :height height
+                                  :width window-width
+                                  :height window-height
                                   :color-type :truecolor-alpha
                                   :image-data buffer)))
           (zpng:write-png png pathname))))))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -134,6 +134,10 @@
            :with-rotate
            :with-scale
 
+           ;; Complex transforms
+           :fit
+           :with-fit
+
            ;; Channels
            :register-input
            :in

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -19,6 +19,8 @@
            :sketch-title
            :sketch-width
            :sketch-height
+           :sketch-window-width
+           :sketch-window-height
            :sketch-fullscreen
            :sketch-resizable
            :sketch-copy-pixels
@@ -27,6 +29,8 @@
            :title
            :width
            :height
+           :window-width
+           :window-height
            :fullscreen
            :resizable
            :copy-pixels
@@ -34,6 +38,8 @@
 
            :*default-width*
            :*default-height*
+           :*default-window-width*
+           :*default-window-height*
 
            ;; Math
            :clamp-1

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -22,7 +22,7 @@
            :sketch-window-width
            :sketch-window-height
            :sketch-fullscreen
-           :sketch-resizable
+           :sketch-resize
            :sketch-copy-pixels
            :sketch-y-axis
 
@@ -32,7 +32,7 @@
            :window-width
            :window-height
            :fullscreen
-           :resizable
+           :resize
            :copy-pixels
            :y-axis
 

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -39,7 +39,7 @@
       (window-width :initform *default-window-width* :accessor sketch-window-width :initarg :window-width)
       (window-height :initform *default-window-height* :accessor sketch-window-height :initarg :window-height)
       (fullscreen :initform nil :accessor sketch-fullscreen :initarg :fullscreen)
-      (resizable :initform nil :accessor sketch-resizable :initarg :resizable)
+      (resize :initform nil :accessor sketch-resize :initarg :resize)
       (copy-pixels :initform nil :accessor sketch-copy-pixels :initarg :copy-pixels)
       (y-axis :initform :down :accessor sketch-y-axis :initarg :y-axis))))
 
@@ -64,30 +64,30 @@
 
 (define-sketch-writer window-width
   (sdl2:set-window-size win value (sketch-window-height instance))
-  (when (member (sketch-resizable instance) '(t :none nil))
+  (when (member (sketch-resize instance) '(t :none nil))
     (setf (slot-value instance 'width) value))
   (initialize-view-matrix instance))
 
 (define-sketch-writer window-height
   (sdl2:set-window-size win (sketch-window-width instance) value)
-  (when (member (sketch-resizable instance) '(t :none nil))
+  (when (member (sketch-resize instance) '(t :none nil))
     (setf (slot-value instance 'height) value))
   (initialize-view-matrix instance))
 
 (define-sketch-writer width
   (declare (ignore win))
-  (when (member (sketch-resizable instance) '(t :none nil))
+  (when (member (sketch-resize instance) '(t :none nil))
     (setf (sketch-window-width instance) value)))
 
 (define-sketch-writer height
   (declare (ignore win))
-  (when (member (sketch-resizable instance) '(t :none nil))
+  (when (member (sketch-resize instance) '(t :none nil))
     (setf (sketch-window-height instance) value)))
 
 (define-sketch-writer fullscreen
   (sdl2:set-window-fullscreen win value))
 
-(define-sketch-writer resizable
+(define-sketch-writer resize
   (sdl2-ffi.functions:sdl-set-window-resizable
    win
    (if value sdl2-ffi:+true+ sdl2-ffi:+false+))
@@ -197,19 +197,19 @@ used for drawing, 60fps.")
 ;;; Support for resizable windows
 
 (defmethod kit.sdl2:window-event :before ((instance sketch) (type (eql :size-changed)) timestamp data1 data2)
-  (with-slots ((env %env) window-width window-height width height resizable y-axis) instance
+  (with-slots ((env %env) window-width window-height width height resize y-axis) instance
     (setf window-width data1
           window-height data2)
-    (when (member resizable '(t :none nil))
+    (when (member resize '(t :none nil))
       (setf width data1
             height data2))
     (initialize-view-matrix instance))
   (kit.sdl2:render instance))
 
 (defmethod draw :before ((instance sketch) &key &allow-other-keys)
-  (with-slots (width height window-width window-height resizable) instance
-    (when (member resizable '(:contain :cover :scale-down :fill))
-      (fit width height window-width window-height :mode resizable))))
+  (with-slots (width height window-width window-height resize) instance
+    (when (member resize '(:contain :cover :scale-down :fill))
+      (fit width height window-width window-height :mode resize))))
 
 ;;; Default events
 

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -22,15 +22,22 @@
   "The current sketch instance.")
 
 (defparameter *default-width* 400
-  "The default width of sketch window")
+  "The default width of the sketch drawing area")
 (defparameter *default-height* 400
-  "The default height of sketch window")
+  "The default height of the sketch drawing area")
+
+(defparameter *default-window-width* 400
+  "The default width of the sketch window")
+(defparameter *default-window-height* 400
+  "The default height of the sketch window")
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defparameter *default-slots*
     '((title :initform "Sketch" :accessor sketch-title :initarg :title)
       (width :initform *default-width* :accessor sketch-width :initarg :width)
       (height :initform *default-height* :accessor sketch-height :initarg :height)
+      (window-width :initform *default-window-width* :accessor sketch-window-width :initarg :window-width)
+      (window-height :initform *default-window-height* :accessor sketch-window-height :initarg :window-height)
       (fullscreen :initform nil :accessor sketch-fullscreen :initarg :fullscreen)
       (resizable :initform nil :accessor sketch-resizable :initarg :resizable)
       (copy-pixels :initform nil :accessor sketch-copy-pixels :initarg :copy-pixels)

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -62,12 +62,12 @@
 (define-sketch-writer title
   (sdl2:set-window-title win value))
 
-(define-sketch-writer width
-  (sdl2:set-window-size win value (sketch-height instance))
+(define-sketch-writer window-width
+  (sdl2:set-window-size win value (sketch-window-height instance))
   (initialize-view-matrix instance))
 
-(define-sketch-writer height
-  (sdl2:set-window-size win (sketch-width instance) value)
+(define-sketch-writer window-height
+  (sdl2:set-window-size win (sketch-window-width instance) value)
   (initialize-view-matrix instance))
 
 (define-sketch-writer fullscreen
@@ -149,11 +149,11 @@ used for drawing, 60fps.")
   (end-draw))
 
 (defmethod kit.sdl2:render ((instance sketch))
-  (with-slots (%env %restart width height copy-pixels %viewport-changed) instance
+  (with-slots (%env %restart window-width window-height copy-pixels %viewport-changed) instance
     (when %viewport-changed
       (kit.gl.shader:uniform-matrix
        (env-programs %env) :view-m 4 (vector (env-view-matrix %env)))
-      (gl:viewport 0 0 width height)
+      (gl:viewport 0 0 window-width window-height)
       (setf %viewport-changed nil))
     (with-environment %env
       (with-pen (make-default-pen)
@@ -180,9 +180,9 @@ used for drawing, 60fps.")
 ;;; Support for resizable windows
 
 (defmethod kit.sdl2:window-event :before ((instance sketch) (type (eql :size-changed)) timestamp data1 data2)
-  (with-slots ((env %env) width height y-axis) instance
-    (setf width data1
-          height data2)
+  (with-slots ((env %env) window-width window-height y-axis) instance
+    (setf window-width data1
+          window-height data2)
     (initialize-view-matrix instance))
   (kit.sdl2:render instance))
 

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -206,6 +206,11 @@ used for drawing, 60fps.")
     (initialize-view-matrix instance))
   (kit.sdl2:render instance))
 
+(defmethod draw :before ((instance sketch) &key &allow-other-keys)
+  (with-slots (width height window-width window-height resizable) instance
+    (when (member resizable '(:contain :cover :scale-down :fill))
+      (fit width height window-width window-height :mode resizable))))
+
 ;;; Default events
 
 (defmethod kit.sdl2:keyboard-event :before ((instance sketch) state timestamp repeatp keysym)


### PR DESCRIPTION
Renames `resizable` slot to `resize` (this change can be easily dropped);
Adds `window-width` and `window-height` slots;
Allows to specify different fit modes to be automatically applied in `resizable` slot.

Depends on / contains #105.