### PR TITLE
Generalize bindings

### DIFF
--- a/sketch.asd
+++ b/sketch.asd
@@ -35,6 +35,7 @@
                (:file "image")
                (:file "shapes")
                (:file "transforms")
+	       (:file "bindings")
                (:file "sketch")
                (:file "figures")
                (:file "controllers")

--- a/sketch.asd
+++ b/sketch.asd
@@ -6,6 +6,7 @@
   :license "MIT"
   :depends-on (#:alexandria
                #:cl-geometry
+	       #:closer-mop
                #:glkit
                #:mathkit
                #:md5

--- a/src/bindings.lisp
+++ b/src/bindings.lisp
@@ -34,9 +34,10 @@
                           :channel-name channel-name
                           :channelp channel-name-p))
 
-(defun parse-bindings (prefix bindings &optional default-slots)
+(defun parse-bindings (prefix bindings &optional custom-name-prefix-alist)
   (loop for (name value . args) in (alexandria:ensure-list bindings)
-        for default-slot-p = (assoc name default-slots)
+        for name-prefix = (or (cdr (assoc name custom-name-prefix-alist))
+			      prefix)
         ;; If a VALUE is of form (IN CHANNEL-NAME DEFAULT-VALUE) it
         ;; is recognized as a channel. We should pass additional
         ;; :channel-name parameter to MAKE-BINDING and set the VALUE
@@ -48,6 +49,6 @@
         collect (apply #'make-binding
 		       (list*
 			name
-			(if default-slot-p 'sketch prefix)
+			name-prefix
 			:initform value
-			(if default-slot-p (cdddr default-slot-p) args)))))
+			args))))

--- a/src/bindings.lisp
+++ b/src/bindings.lisp
@@ -1,0 +1,53 @@
+;;;; bindings.lisp
+
+(in-package #:sketch)
+
+;;;  ____ ___ _   _ ____ ___ _   _  ____ ____
+;;; | __ )_ _| \ | |  _ \_ _| \ | |/ ___/ ___|
+;;; |  _ \| ||  \| | | | | ||  \| | |  _\___ \
+;;; | |_) | || |\  | |_| | || |\  | |_| |___) |
+;;; |____/___|_| \_|____/___|_| \_|\____|____/
+
+(defclass binding ()
+  ((name :initarg :name :accessor binding-name)
+   (prefix :initarg :prefix :accessor binding-prefix)
+   (initform :initarg :initform :accessor binding-initform)
+   (defaultp :initarg :defaultp :accessor binding-defaultp)
+   (initarg :initarg :initarg :accessor binding-initarg)
+   (accessor :initarg :accessor :accessor binding-accessor)
+   (channelp :initarg :channelp :accessor binding-channelp)
+   (channel-name :initarg :channel-name :accessor binding-channel-name)))
+
+(defun make-binding (name prefix
+		     &key
+		       (defaultp nil)
+		       (initform nil)
+		       (initarg (alexandria:make-keyword name))
+		       (accessor (alexandria:symbolicate prefix '#:- name))
+		       (channel-name nil channel-name-p))
+  (make-instance 'binding :name name
+                          :prefix prefix
+                          :defaultp defaultp
+                          :initform initform
+                          :initarg initarg
+                          :accessor accessor
+                          :channel-name channel-name
+                          :channelp channel-name-p))
+
+(defun parse-bindings (prefix bindings &optional default-slots)
+  (loop for (name value . args) in (alexandria:ensure-list bindings)
+        for default-slot-p = (assoc name default-slots)
+        ;; If a VALUE is of form (IN CHANNEL-NAME DEFAULT-VALUE) it
+        ;; is recognized as a channel. We should pass additional
+        ;; :channel-name parameter to MAKE-BINDING and set the VALUE
+        ;; to the DEFAULT-VALUE.
+        when (and (consp value)
+                  (eq 'in (car value)))
+          do (setf args (list* :channel-name (second value) args)
+                   value (third value))
+        collect (apply #'make-binding
+		       (list*
+			name
+			(if default-slot-p 'sketch prefix)
+			:initform value
+			(if default-slot-p (cdddr default-slot-p) args)))))

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -203,7 +203,7 @@
 
 (defclass binding ()
   ((name :initarg :name :accessor binding-name)
-   (sketch-name :initarg :sketch-name :accessor binding-sketch-name)
+   (prefix :initarg :prefix :accessor binding-prefix)
    (initform :initarg :initform :accessor binding-initform)
    (defaultp :initarg :defaultp :accessor binding-defaultp)
    (initarg :initarg :initarg :accessor binding-initarg)
@@ -211,14 +211,14 @@
    (channelp :initarg :channelp :accessor binding-channelp)
    (channel-name :initarg :channel-name :accessor binding-channel-name)))
 
-(defun make-binding (name &key (sketch-name 'sketch)
+(defun make-binding (name &key (prefix 'sketch)
                                (defaultp nil)
                                (initform nil)
                                (initarg (alexandria:make-keyword name))
-                               (accessor (alexandria:symbolicate sketch-name '#:- name))
+                               (accessor (alexandria:symbolicate prefix '#:- name))
                                (channel-name nil channel-name-p))
   (make-instance 'binding :name name
-                          :sketch-name sketch-name
+                          :prefix prefix
                           :defaultp defaultp
                           :initform initform
                           :initarg initarg
@@ -232,7 +232,7 @@
         do (push (apply #'make-binding name :defaultp t args) parsed-bindings))
   parsed-bindings)
 
-(defun parse-bindings (sketch-name bindings)
+(defun parse-bindings (prefix bindings)
   (add-default-bindings
    (loop for (name value . args) in (alexandria:ensure-list bindings)
          for default-slot-p = (assoc name *default-slots*)
@@ -249,7 +249,7 @@
                         :initform value
                         (if default-slot-p
                             (cdddr default-slot-p)
-                            (list* :sketch-name sketch-name args))))))
+                            (list* :prefix prefix args))))))
 
 ;;; DEFSKETCH channels
 
@@ -268,7 +268,7 @@
 (defun define-sketch-defclass (name bindings)
   `(defclass ,name (sketch)
      (,@(loop for b in bindings
-              unless (eq 'sketch (binding-sketch-name b))
+              unless (eq 'sketch (binding-prefix b))
               collect `(,(binding-name b)
                         :initarg ,(binding-initarg b)
                         :accessor ,(binding-accessor b))))))

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -251,7 +251,9 @@
 
 (defmacro defsketch (sketch-name bindings &body body)
   (let ((bindings (add-default-bindings
-		   (parse-bindings sketch-name bindings *default-slots*))))
+		   (parse-bindings sketch-name bindings
+				   (mapcar (lambda (s) (cons (car s) 'sketch))
+					   *default-slots*)))))
     `(progn
        ,(define-sketch-defclass sketch-name bindings)
        ,@(define-channel-observers bindings)


### PR DESCRIPTION
Makes bindings more generally usable, in hope of supporting "entities" (widgets?) in future, and cleaning up the code in general.