### PR TITLE
Don't triangulate polygon if it's already a triangle.

### DIFF
--- a/src/shapes.lisp
+++ b/src/shapes.lisp
@@ -126,7 +126,11 @@
 (defun make-polygon (&rest coordinates)
   (list
    :triangles
-   (triangulate coordinates)
+   (if (= 3 (/ (length coordinates) 2))
+       ;; Special case, it's just a single triangle, don't need
+       ;; to triangulate it.
+       (group coordinates)
+       (triangulate coordinates))
    (group coordinates)))
 
 (defun polygon (&rest coordinates)


### PR DESCRIPTION
A workaround for the `polygon` bug, for the case where the user just wants to draw a triangle: https://github.com/vydd/sketch/issues/15

Instead of trying to triangulate, just pass the triangle coordinates directly to `draw-shape`.

### Testing
I used this fix to get one of my sketches working, see: https://github.com/Kevinpgalligan/sketches/blob/master/src/thesketches/snow.lisp#L60-L61

Without this fix, that sketch crashes immediately.