### PR TITLE
Renames the control flow functions

### DIFF
--- a/README.org
+++ b/README.org
@@ -538,9 +538,9 @@ Here is an example usage of =setup= from [[https://github.com/vydd/sketch/blob/m
 Example: [[https://github.com/vydd/sketch/blob/master/examples/stars.lisp][stars.lisp]].
 
 *** Control flow
-=(loop-no)= from within a sketch body or within an event handler to disable the drawing loop.
+=(stop-loop)= from within a sketch body or within an event handler to disable the drawing loop.
 
-=(loop-yes)= to start the drawing loop again.
+=(start-loop)= to start the drawing loop again.
 
 This can be used, for example, to draw a static sketch and then disable the drawing loop so as to not burn up your CPU. It can also be used to regenerate the sketch with each mouseclick.
 

--- a/examples/control-flow.lisp
+++ b/examples/control-flow.lisp
@@ -3,12 +3,12 @@
 ;; Regenerate the sketch, drawing a circle in a new place, every
 ;; time there's a click.
 
-(defsketch controlflow
+(defsketch control-flow
     ((title "Control Flow")
      (width 400)
      (height 400))
-  (circle (random width) (random height))
-  (loop-no))
+  (circle (random width) (random height) 20)
+  (stop-loop))
 
-(defmethod onclick ((sketch controlflow) x y)
-  (loop-yes))
+(defmethod on-click ((sketch control-flow) x y)
+  (start-loop))

--- a/examples/package.lisp
+++ b/examples/package.lisp
@@ -8,4 +8,5 @@
            :sinewave
            :stars
            :indigo
+           :control-flow
            ))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -191,6 +191,6 @@
            :on-leave
 
            ;; Control flow
-           :loop-yes
-           :loop-no
+           :start-loop
+           :stop-loop
            ))

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -259,8 +259,8 @@
 
 ;;; Control flow
 
-(defun loop-no ()
+(defun stop-loop ()
   (setf (sdl2.kit:idle-render *sketch*) nil))
 
-(defun loop-yes ()
+(defun start-loop ()
   (setf (sdl2.kit:idle-render *sketch*) t))


### PR DESCRIPTION
- `LOOP-YES` is now `START-LOOP`
- `LOOP-NO` is now `STOP-LOOP`
- Fixes the `CONTROL-FLOW` example, exports it