### PR TITLE
Extend triangulate optimisation to quadrilaterals.

### DIFF
--- a/README.org
+++ b/README.org
@@ -159,6 +159,9 @@ Let's draw something!
 
 #+BEGIN_SRC lisp
   (defsketch tutorial ()
+    ;; Note: The sides of polygons must be non-self-intersecting, and if
+    ;; there are more than 4 sides then the coordinates must be rationals and
+    ;; not floats.
     (polygon 100 100 200 150 300 100 200 200))
 #+END_SRC
 

--- a/src/geometry.lisp
+++ b/src/geometry.lisp
@@ -69,13 +69,19 @@
     (append (cdr polygon) (list (car polygon)))))
 
 (defun triangulate (polygon)
-  (if (= 3 (/ (length polygon) 2))
-      (group polygon)       ;; No need to triangulate - it's a triangle.
-      (mapcar (lambda (point) (list (2d-geometry:x point) (2d-geometry:y point)))
-              (apply #'append
-                     (mapcar #'2d-geometry:point-list
-                             (2d-geometry:decompose-complex-polygon-triangles
-                              (apply #'2d-geometry:make-polygon-from-coords polygon)))))))
+  (let ((num-vertices (/ (length polygon) 2)))
+    (case num-vertices
+      (3 (group polygon)) ; No need to triangulate - it's a triangle.
+      (4 (destructuring-bind (p1 p2 p3 p4) (group polygon)
+           ;; Quadrilateral, simple to divide it up into 2 triangles.
+           (list p1 p2 p3 p1 p3 p4)))
+      (t
+       (mapcar
+        (lambda (point) (list (2d-geometry:x point) (2d-geometry:y point)))
+        (apply #'append
+               (mapcar #'2d-geometry:point-list
+                       (2d-geometry:decompose-complex-polygon-triangles
+                        (apply #'2d-geometry:make-polygon-from-coords polygon)))))))))
 
 (defun bounding-box (vertices)
   (loop for (x y) in vertices


### PR DESCRIPTION
Avoids calling the `2d-geometry` package if the polygon in question has 4 sides, since we can easily triangulate it by hand.

Also added a comment to the `polygon` code example in the docs that describes the limitations of this drawing function.

Testing:

```
(defsketch triangle-test ()
   (polygon 90 90 100 100 110 90) ; triangle
   (polygon 0 0 0 40 20 35 40 20) ; quadrilateral
   (polygon 150 150 170 150 180 180 170 180 150 180) ; 5-sided polygon
   (stop-loop))
```

(Can call `(trace 2d-geometry:make-polygon-from-coords)` to show that the heavyweight triangulation code is only getting called for the 5-sided polygon).