### PR TITLE
Adds shorthand versions of with-pen and with-font

### DIFF
--- a/src/font.lisp
+++ b/src/font.lisp
@@ -28,12 +28,13 @@
                    :align (or align :left))))
 
 (defmacro with-font (font &body body)
-  (alexandria:with-gensyms (previous-font)
-    `(let ((,previous-font (env-font *env*)))
-       (unwind-protect (progn
-                         (setf (env-font *env*) ,font)
-                         ,@body)
-         (setf (env-font *env*) ,previous-font)))))
+  (with-shorthand (font make-font)
+    (alexandria:with-gensyms (previous-font)
+      `(let ((,previous-font (env-font *env*)))
+         (unwind-protect (progn
+                           (setf (env-font *env*) ,font)
+                           ,@body)
+           (setf (env-font *env*) ,previous-font))))))
 
 (defun set-font (font)
   (setf (env-font *env*) font))

--- a/src/pen.lisp
+++ b/src/pen.lisp
@@ -15,12 +15,13 @@
   (curve-steps 100))
 
 (defmacro with-pen (pen &body body)
-  (alexandria:with-gensyms (previous-pen)
-    `(let ((,previous-pen (env-pen *env*)))
-       (unwind-protect (progn
-                         (setf (env-pen *env*) ,pen)
-                         ,@body)
-         (setf (env-pen *env*) ,previous-pen)))))
+  (with-shorthand (pen make-pen)
+    (alexandria:with-gensyms (previous-pen)
+      `(let ((,previous-pen (env-pen *env*)))
+         (unwind-protect (progn
+                           (setf (env-pen *env*) ,pen)
+                           ,@body)
+           (setf (env-pen *env*) ,previous-pen))))))
 
 (defun set-pen (pen)
   "Sets environment pen to PEN."

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -97,3 +97,9 @@ but may be considered unique for all practical purposes."
 (defun surface-format (surface)
   (plus-c:c-let ((surface sdl2-ffi:sdl-surface :from surface))
     (surface :format :format)))
+
+(defmacro with-shorthand ((var maker) &body body)
+  `(let ((,var (if (and (listp ,var) (keywordp (car ,var)))
+                 (cons ',maker ,var)
+                 ,var)))
+     ,@body))


### PR DESCRIPTION
`make-pen` and `make-font` are automatically added when `with-pen` and `with-font` are used just with constructor plists, for example:

```lisp
(with-pen (:stroke +white+ :fill +black+)
  (rect 100 100 100 100))
```