### PR TITLE
Interns defsketch accessors into the proper package

### DIFF
--- a/src/bindings.lisp
+++ b/src/bindings.lisp
@@ -16,6 +16,7 @@
 (defclass binding ()
   ((name :initarg :name :accessor binding-name)
    (prefix :initarg :prefix :accessor binding-prefix)
+   (package :intiarg :package :accessor binding-package)
    (initform :initarg :initform :accessor binding-initform)
    (defaultp :initarg :defaultp :accessor binding-defaultp)
    (initarg :initarg :initarg :accessor binding-initarg)
@@ -25,11 +26,11 @@
 
 (defun make-binding (name prefix
                      &key
-                       (defaultp nil)
+                       (package nil)
                        (initform nil)
+                       (defaultp nil)
                        (initarg (alexandria:make-keyword name))
-                       (accessor (intern (symbol-name (alexandria:symbolicate prefix '#:- name))
-                                         (symbol-package prefix)))
+                       (accessor (make-accessor name prefix package))
                        (channel-name nil)
                        (channelp (and channel-name t)))
   (make-instance 'binding :name name
@@ -40,6 +41,12 @@
                           :accessor accessor
                           :channel-name channel-name
                           :channelp channelp))
+
+(defun make-accessor (name prefix package)
+  (let ((symbol (alexandria:symbolicate prefix '#:- name)))
+    (if package
+        (intern (symbol-name symbol) (symbol-package prefix))
+        symbol)))
 
 (defun copy-binding (binding
                      &key
@@ -64,6 +71,7 @@
           collect (make-binding
                    name
                    (class-name class)
+                   :package (symbol-package (class-name class))
                    :defaultp mark-default-p
                    :initform initform)))
 

--- a/src/bindings.lisp
+++ b/src/bindings.lisp
@@ -28,7 +28,8 @@
                        (defaultp nil)
                        (initform nil)
                        (initarg (alexandria:make-keyword name))
-                       (accessor (alexandria:symbolicate prefix '#:- name))
+                       (accessor (intern (symbol-name (alexandria:symbolicate prefix '#:- name))
+                                         (symbol-package prefix)))
                        (channel-name nil)
                        (channelp (and channel-name t)))
   (make-instance 'binding :name name

--- a/src/bindings.lisp
+++ b/src/bindings.lisp
@@ -16,9 +16,9 @@
 (defclass binding ()
   ((name :initarg :name :accessor binding-name)
    (prefix :initarg :prefix :accessor binding-prefix)
-   (package :intiarg :package :accessor binding-package)
-   (initform :initarg :initform :accessor binding-initform)
+   (package :initarg :package :accessor binding-package)
    (defaultp :initarg :defaultp :accessor binding-defaultp)
+   (initform :initarg :initform :accessor binding-initform)
    (initarg :initarg :initarg :accessor binding-initarg)
    (accessor :initarg :accessor :accessor binding-accessor)
    (channelp :initarg :channelp :accessor binding-channelp)
@@ -27,14 +27,15 @@
 (defun make-binding (name prefix
                      &key
                        (package nil)
-                       (initform nil)
                        (defaultp nil)
+                       (initform nil)
                        (initarg (alexandria:make-keyword name))
                        (accessor (make-accessor name prefix package))
                        (channel-name nil)
                        (channelp (and channel-name t)))
   (make-instance 'binding :name name
                           :prefix prefix
+                          :package package
                           :defaultp defaultp
                           :initform initform
                           :initarg initarg


### PR DESCRIPTION
Makes it possible to work with sketch without :use