### PR TITLE
Make xy keyword args in draw

### DIFF
--- a/src/canvas.lisp
+++ b/src/canvas.lisp
@@ -64,8 +64,8 @@
 (defmethod canvas-unlock ((canvas canvas))
   (setf (%canvas-locked canvas) nil))
 
-(defmethod draw ((canvas canvas) x y
-                 &key width height mode
+(defmethod draw ((canvas canvas)
+                 &key (x 0) (y 0) width height mode
                    (min-filter :linear)
                    (mag-filter :linear)
                  &allow-other-keys)
@@ -82,7 +82,7 @@ there instead.
 See: https://registry.khronos.org/OpenGL-Refpages/gl4/html/glTexParameter.xhtml"
   (declare (ignore mode))
   (draw (canvas-image canvas :min-filter min-filter :mag-filter mag-filter)
-        0
-        0
+        :x x
+        :y y
         :width (or width (canvas-width canvas))
         :height (or height (canvas-height canvas))))

--- a/src/entities.lisp
+++ b/src/entities.lisp
@@ -50,8 +50,8 @@
                              ,(binding-initform b))))))
 
 (defun define-entity-draw-method (name bindings body)
-  `(defmethod draw ((*entity* ,name) x y
-                    &key (width (entity-width *entity*)) (height (entity-height *entity*)) mode
+  `(defmethod draw ((*entity* ,name)
+                    &key (x 0) (y 0) (width (entity-width *entity*)) (height (entity-height *entity*)) mode
                     &allow-other-keys)
      (declare (ignore mode))
      (let ((from-width width)

--- a/src/image.lisp
+++ b/src/image.lisp
@@ -8,7 +8,7 @@
 ;;  | || |  | |/ ___ \ |_| | |___ ___) |
 ;; |___|_|  |_/_/   \_\____|_____|____/
 
-(defmethod draw ((image image) x y &key width height mode &allow-other-keys)
+(defmethod draw ((image image) &key (x 0) (y 0) width height mode &allow-other-keys)
   "Draws an image, X and Y values are 0 by default, while WIDTH and HEIGHT
 are set to the width & height of the image if not provided."
   (declare (ignore mode))
@@ -22,7 +22,7 @@ are set to the width & height of the image if not provided."
 
 (defun image (image-resource x y &optional width height)
   "***Deprecated***, use the DRAW method."
-  (draw image-resource x y :width width :height height))
+  (draw image-resource :x x :y y :width width :height height))
 
 (defmethod crop ((image-resource image) x y w h)
   "Generate a cropped image resource from IMAGE-RESOURCE, limiting how much of the image is drawn

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -80,9 +80,9 @@
   (:documentation "Called before creating the sketch window.")
   (:method ((instance sketch) &key &allow-other-keys) ()))
 
-(defgeneric draw (instance x y &key width height mode &allow-other-keys)
+(defgeneric draw (instance &key x y width height mode &allow-other-keys)
   (:documentation "Draws the instance with set position, dimensions, and scaling mode.")
-  (:method ((instance sketch) x y &key width height mode &allow-other-keys)
+  (:method ((instance sketch) &key x y width height mode &allow-other-keys)
     "Called repeatedly after creating the sketch window, 60fps."
     (declare (ignore x y width height mode))
     ()))
@@ -138,7 +138,7 @@
 
 (defun draw-window (window)
   (start-draw)
-  (draw window 0 0)
+  (draw window)
   (end-draw))
 
 (defmacro with-sketch ((sketch) &body body)
@@ -226,7 +226,7 @@
                                  ,(binding-initform b))))))))
 
 (defun define-sketch-draw-method (name bindings body)
-  `(defmethod draw ((*sketch* ,name) x y &key width height mode &allow-other-keys)
+  `(defmethod draw ((*sketch* ,name) &key x y width height mode &allow-other-keys)
      (declare (ignore x y width height mode))
      (with-accessors (,@(loop for b in bindings
                               collect `(,(binding-name b) ,(binding-accessor b))))


### PR DESCRIPTION
As discussed in Discord. Benefits:
- Allows default of (0,0).
- User may wish to use translations to determine where to draw, it then becomes inelegant that they have to pass (0,0).
- x & y coordinates can be part of the object that's being drawn, e.g. an entity that has slots containing its position.

(I still have to test these changes, just submitting this 'cause it would've been a waste of time to create an issue for a change that took 5 mins).