### PR TITLE
Don't draw border around images.

### DIFF
--- a/src/image.lisp
+++ b/src/image.lisp
@@ -13,8 +13,8 @@
 are set to the width & height of the image if not provided."
   (declare (ignore mode))
   (with-pen (make-pen :fill image
-                      :stroke 0
-                      :weight 0)
+                      :stroke nil
+                      :weight nil)
     (rect x
           y
           (or (abs-or-rel width (image-width image)))

--- a/src/image.lisp
+++ b/src/image.lisp
@@ -13,8 +13,8 @@
 are set to the width & height of the image if not provided."
   (declare (ignore mode))
   (with-pen (make-pen :fill image
-                      :stroke (pen-stroke (env-pen *env*))
-                      :weight (pen-weight (env-pen *env*)))
+                      :stroke 0
+                      :weight 0)
     (rect x
           y
           (or (abs-or-rel width (image-width image)))


### PR DESCRIPTION
By default, we currently draw a border around images. This leaks the implementation details of how images are drawn (i.e. by filling a rect), instead we can let the user draw their own border if they want.

Tested:

    (defsketch imagetest
            ((pic (load-resource "/path/to/image.png")))
          (draw pic))