### PR TITLE
Separate sketch window class

### DIFF
--- a/src/canvas.lisp
+++ b/src/canvas.lisp
@@ -53,13 +53,16 @@
        :mag-filter mag-filter)))
 
 (defmethod canvas-lock ((canvas canvas)
+                        &rest r
                         &key (min-filter :linear)
                              (mag-filter :linear)
                         &allow-other-keys)
-  (setf (%canvas-image canvas) (canvas-image canvas
-                                             :min-filter min-filter
-                                             :mag-filter mag-filter)
-        (%canvas-locked canvas) t))
+  (if (delay-init-p)
+      (add-delayed-init-fun! (lambda () (apply #'canvas-lock canvas r)))
+      (setf (%canvas-image canvas) (canvas-image canvas
+                                                 :min-filter min-filter
+                                                 :mag-filter mag-filter)
+            (%canvas-locked canvas) t)))
 
 (defmethod canvas-unlock ((canvas canvas))
   (setf (%canvas-locked canvas) nil))

--- a/src/canvas.lisp
+++ b/src/canvas.lisp
@@ -53,16 +53,13 @@
        :mag-filter mag-filter)))
 
 (defmethod canvas-lock ((canvas canvas)
-                        &rest r
                         &key (min-filter :linear)
                              (mag-filter :linear)
                         &allow-other-keys)
-  (if (delay-init-p)
-      (add-delayed-init-fun! (lambda () (apply #'canvas-lock canvas r)))
-      (setf (%canvas-image canvas) (canvas-image canvas
-                                                 :min-filter min-filter
-                                                 :mag-filter mag-filter)
-            (%canvas-locked canvas) t)))
+  (setf (%canvas-image canvas) (canvas-image canvas
+                                             :min-filter min-filter
+                                             :mag-filter mag-filter)
+        (%canvas-locked canvas) t))
 
 (defmethod canvas-unlock ((canvas canvas))
   (setf (%canvas-locked canvas) nil))

--- a/src/controllers.lisp
+++ b/src/controllers.lisp
@@ -8,7 +8,6 @@
 ;;; | |__| |_| | |\  | | | |  _ <| |_| | |___| |___| |___|  _ < ___) |
 ;;;  \____\___/|_| \_| |_| |_| \_\\___/|_____|_____|_____|_| \_\____/
 
-
 ;;; Mouse
 
 (defparameter *buttons* (list :left nil :middle nil :right nil))
@@ -57,8 +56,8 @@
 
 (defmethod kit.sdl2:mousebutton-event ((instance sketch-window) state timestamp button x y)
   ;; For backward compatibility.
-  (kit.sdl2:mousebutton-event (sketch instance) state timestamp button x y)
-  (with-slots (sketch) instance
+  (kit.sdl2:mousebutton-event (%sketch instance) state timestamp button x y)
+  (with-slots ((sketch %sketch)) instance
     (let ((button (elt (list nil :left :middle :right) button))
           (click-method (elt (list nil #'on-press #'on-middle-press #'on-right-press) button))
           (release-method (elt (list nil #'on-click #'on-middle-click #'on-right-click) button)))
@@ -71,8 +70,8 @@
 
 (defmethod kit.sdl2:mousemotion-event ((instance sketch-window) timestamp button-mask x y xrel yrel)
   ;; For backward compatibility.
-  (kit.sdl2:mousemotion-event (sketch instance) timestamp button-mask x y xrel yrel)
-  (with-slots (sketch) instance
+  (kit.sdl2:mousemotion-event (%sketch instance) timestamp button-mask x y xrel yrel)
+  (with-slots ((sketch %sketch)) instance
     (on-hover sketch x y)
     (unless
         (loop for entity being the hash-key of (sketch-%entities sketch)
@@ -102,7 +101,7 @@
 
 (defmethod kit.sdl2:mousebutton-event :after ((instance sketch-window)
                                               state timestamp button x y)
-  (with-slots (%env) (sketch instance)
+  (with-slots (%env) (%sketch instance)
     (when (env-red-screen %env)
       (setf (env-debug-key-pressed %env) t))))
 
@@ -124,40 +123,14 @@
       (call-next-method))))
 
 (defmethod kit.sdl2:textinput-event :after ((instance sketch-window) timestamp text)
-  (on-text (sketch instance) text))
+  (on-text (%sketch instance) text))
 
 (defmethod kit.sdl2:keyboard-event :after ((instance sketch-window) state timestamp repeat-p keysym)
   (when (not repeat-p)
-    (on-key (sketch instance)
+    (on-key (%sketch instance)
             ;; Removing the ugly "SCANCODE-" prefix from the keyword
             ;; symbol that denotes the button.
             (intern (subseq (symbol-name (sdl2:scancode keysym))
                             +scancode-prefix-length+)
                     (find-package "KEYWORD"))
             state)))
-
-;;; Backward compatibility.
-;; Previously, the main `sketch` class inherited from
-;; `kit.sdl2:gl-window`, and input was handled by specialising on methods from
-;; sdl2kit. So we need to forward sdl2kit input calls to the `sketch` class for
-;; old sketches that rely on that approach.
-(defmacro define-sdl2-forward (name (&rest args) &optional already-defined?)
-  `(progn
-     ;; An empty method so we don't get an error if we try to forward
-     ;; when the user hasn't defined it.
-     (defmethod ,name ((w sketch) ,@args))
-     ,@(when (not already-defined?)
-         `((defmethod ,name ((w sketch-window) ,@args)
-             (,name (sketch w) ,@args)
-             (call-next-method))))))
-(define-sdl2-forward kit.sdl2:mousebutton-event (state timestamp button x y) t)
-(define-sdl2-forward kit.sdl2:mousemotion-event (timestamp button-mask x y xrel yrel) t)
-(define-sdl2-forward kit.sdl2:close-window () t)
-(define-sdl2-forward kit.sdl2:textinput-event (timestamp text))
-(define-sdl2-forward kit.sdl2:keyboard-event (state timestamp repeatp keysym))
-(define-sdl2-forward kit.sdl2:mousewheel-event (timestamp x y))
-(define-sdl2-forward kit.sdl2:window-event (type timestamp data1 data2))
-(define-sdl2-forward kit.sdl2:controller-added-event (c))
-(define-sdl2-forward kit.sdl2:controller-removed-event (c))
-(define-sdl2-forward kit.sdl2:controller-axis-motion-event (controller timestamp axis value))
-(define-sdl2-forward kit.sdl2:controller-button-event (controller state timestamp button))

--- a/src/controllers.lisp
+++ b/src/controllers.lisp
@@ -152,6 +152,7 @@
              (call-next-method))))))
 (define-sdl2-forward kit.sdl2:mousebutton-event (state timestamp button x y) t)
 (define-sdl2-forward kit.sdl2:mousemotion-event (timestamp button-mask x y xrel yrel) t)
+(define-sdl2-forward kit.sdl2:close-window () t)
 (define-sdl2-forward kit.sdl2:textinput-event (timestamp text))
 (define-sdl2-forward kit.sdl2:keyboard-event (state timestamp repeatp keysym))
 (define-sdl2-forward kit.sdl2:mousewheel-event (timestamp x y))

--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -27,7 +27,8 @@
   (resources (make-hash-table))
   ;; Debugging
   (debug-key-pressed nil)
-  (red-screen nil))
+  (red-screen nil)
+  (delayed-resource-creation-funs nil))
 
 (defparameter *env* nil)
 
@@ -59,7 +60,7 @@
           %viewport-changed t)))
 
 (defun initialize-gl (sketch)
-  (with-slots ((w window)) sketch
+  (with-slots ((w %window)) sketch
     (handler-case (sdl2:gl-set-swap-interval 1)
       ;; Some OpenGL drivers do not allow to control swapping.
       ;; In this case SDL2 sets an error that needs to be cleared.

--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -72,7 +72,7 @@
     (gl:blend-func :src-alpha :one-minus-src-alpha)
     (gl:hint :line-smooth-hint :nicest)
     (gl:hint :polygon-smooth-hint :nicest)
-    (gl:clear-color 0.0 1.0 0.0 1.0)
+    (gl:clear-color 0.0 0.0 0.0 1.0)
     (gl:clear :color-buffer :depth-buffer)
     (gl:flush)))
 

--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -39,27 +39,27 @@
     (gl:tex-image-2d :texture-2d 0 :rgba 1 1 0 :bgra :unsigned-byte #(255 255 255 255))
     texture))
 
-(defun initialize-environment (w)
-  (with-slots ((env %env) width height y-axis) w
+(defun initialize-environment (sketch)
+  (with-slots ((env %env) width height y-axis) sketch
     (setf (env-programs env) (kit.gl.shader:compile-shader-dictionary 'sketch-programs)
           (env-vao env) (make-instance 'kit.gl.vao:vao :type 'sketch-vao)
           (env-white-pixel-texture env) (make-white-pixel-texture)
           (env-white-color-vector env) #(255 255 255 255)
           (env-pen env) (make-default-pen)
           (env-font env) (make-default-font))
-    (initialize-view-matrix w)
+    (initialize-view-matrix sketch)
     (kit.gl.shader:use-program (env-programs env) :fill-shader)))
 
-(defun initialize-view-matrix (w)
-  (with-slots ((env %env) width height y-axis %viewport-changed) w
+(defun initialize-view-matrix (sketch)
+  (with-slots ((env %env) width height y-axis %viewport-changed) sketch
     (setf (env-view-matrix env) (if (eq y-axis :down)
                                     (kit.glm:ortho-matrix 0 width height 0 -1 1)
                                     (kit.glm:ortho-matrix 0 width 0 height -1 1))
           (env-y-axis-sgn env) (if (eq y-axis :down) +1 -1)
           %viewport-changed t)))
 
-(defun initialize-gl (w)
-  (with-slots ((env %env) width height) w
+(defun initialize-gl (sketch)
+  (with-slots ((w window)) sketch
     (handler-case (sdl2:gl-set-swap-interval 1)
       ;; Some OpenGL drivers do not allow to control swapping.
       ;; In this case SDL2 sets an error that needs to be cleared.

--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -27,8 +27,7 @@
   (resources (make-hash-table))
   ;; Debugging
   (debug-key-pressed nil)
-  (red-screen nil)
-  (delayed-resource-creation-funs nil))
+  (red-screen nil))
 
 (defparameter *env* nil)
 

--- a/src/resources.lisp
+++ b/src/resources.lisp
@@ -105,13 +105,10 @@
                                      (w nil)
                                      (h nil)
                                 &allow-other-keys)
-  (let* ((surface (cut-surface (sdl2-image:load-image filename) x y w h))
-         (img (make-instance 'image
-                             :width (sdl2:surface-width surface)
-                             :height (sdl2:surface-height surface)
-                             :texture nil)))
-    (init-image-texture! img surface :min-filter min-filter :mag-filter mag-filter)
-    img))
+  (make-image-from-surface
+   (cut-surface (sdl2-image:load-image filename) x y w h)
+   :min-filter min-filter
+   :mag-filter mag-filter))
 
 (defun init-image-texture! (image surface &key (free-surface t)
                                             (min-filter :linear)

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -173,9 +173,9 @@
            ,@body)))))
 
 (defmethod kit.sdl2:render ((instance sketch-window))
-  (render (sketch instance)))
+  (kit.sdl2:render (sketch instance)))
 
-(defmethod render ((instance sketch))
+(defmethod kit.sdl2:render ((instance sketch))
   (with-slots (%env %restart width height copy-pixels %viewport-changed) instance
     (when %viewport-changed
       (kit.gl.shader:uniform-matrix

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -114,24 +114,24 @@
 
 (defmethod initialize-instance :around ((instance sketch) &key &allow-other-keys)
   (initialize-sketch)
-  (call-next-method)
+  (sdl2:in-main-thread ()
+    (call-next-method))
   (kit.sdl2:start))
 
 (defmethod initialize-instance :after ((instance sketch) &rest initargs &key &allow-other-keys)
-  (sdl2:in-main-thread ()
-    (apply #'prepare instance initargs)
-    (setf (sketch-window instance)
-          (make-instance 'sketch-window
-                         :title (sketch-title instance)
-                         :w (sketch-width instance)
-                         :h (sketch-height instance)
-                         :fullscreen (sketch-fullscreen instance)
-                         :resizable (if (sketch-resizable instance)
-                                        sdl2-ffi:+true+
-                                        sdl2-ffi:+false+)
-                         :sketch instance))
-    (initialize-environment instance)
-    (initialize-gl instance)))
+  (apply #'prepare instance initargs)
+  (setf (sketch-window instance)
+        (make-instance 'sketch-window
+                       :title (sketch-title instance)
+                       :w (sketch-width instance)
+                       :h (sketch-height instance)
+                       :fullscreen (sketch-fullscreen instance)
+                       :resizable (if (sketch-resizable instance)
+                                      sdl2-ffi:+true+
+                                      sdl2-ffi:+false+)
+                       :sketch instance))
+  (initialize-environment instance)
+  (initialize-gl instance))
 
 (defmethod update-instance-for-redefined-class :after
     ((instance sketch) added-slots discarded-slots property-list &rest initargs)

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -118,19 +118,20 @@
   (kit.sdl2:start))
 
 (defmethod initialize-instance :after ((instance sketch) &rest initargs &key &allow-other-keys)
-  (apply #'prepare instance initargs)
-  (setf (sketch-window instance)
-        (make-instance 'sketch-window
-                       :title (sketch-title instance)
-                       :w (sketch-width instance)
-                       :h (sketch-height instance)
-                       :fullscreen (sketch-fullscreen instance)
-                       :resizable (if (sketch-resizable instance)
-                                      sdl2-ffi:+true+
-                                      sdl2-ffi:+false+)
-                       :sketch instance))
-  (initialize-environment instance)
-  (initialize-gl instance))
+  (sdl2:in-main-thread ()
+    (apply #'prepare instance initargs)
+    (setf (sketch-window instance)
+          (make-instance 'sketch-window
+                         :title (sketch-title instance)
+                         :w (sketch-width instance)
+                         :h (sketch-height instance)
+                         :fullscreen (sketch-fullscreen instance)
+                         :resizable (if (sketch-resizable instance)
+                                        sdl2-ffi:+true+
+                                        sdl2-ffi:+false+)
+                         :sketch instance))
+    (initialize-environment instance)
+    (initialize-gl instance)))
 
 (defmethod update-instance-for-redefined-class :after
     ((instance sketch) added-slots discarded-slots property-list &rest initargs)

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -128,7 +128,7 @@
                        :resizable (if (sketch-resizable instance)
                                       sdl2-ffi:+true+
                                       sdl2-ffi:+false+)
-                       :sketch *sketch*))
+                       :sketch instance))
   (initialize-environment instance)
   (initialize-gl instance))
 

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -172,10 +172,7 @@
          (with-identity-matrix
            ,@body)))))
 
-(defmethod kit.sdl2:render ((instance sketch-window))
-  (kit.sdl2:render (sketch instance)))
-
-(defmethod kit.sdl2:render ((instance sketch))
+(defmethod kit.sdl2:render ((win sketch-window) &aux (instance (sketch win)))
   (with-slots (%env %restart width height copy-pixels %viewport-changed) instance
     (when %viewport-changed
       (kit.gl.shader:uniform-matrix
@@ -203,6 +200,9 @@
             (draw-sketch instance))
           (gl-catch (rgb 0.7 0 0)
             (draw-sketch instance))))))
+
+(defmethod kit.sdl2:render ((instance sketch))
+  (kit.sdl2:render (sketch-%window instance)))
 
 ;;; Support for resizable windows
 
@@ -292,6 +292,13 @@
 
 (defun start-loop ()
   (setf (sdl2.kit:idle-render (sketch-%window *sketch*)) t))
+
+;; For backward compatibility.
+(defmethod kit.sdl2:idle-render ((instance sketch))
+  (kit.sdl2:idle-render (sketch-%window instance)))
+
+(defmethod (setf kit.sdl2:idle-render) (value (instance sketch))
+  (setf (kit.sdl2:idle-render (sketch-%window instance)) value))
 
 ;;; Resource-handling
 

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -211,7 +211,7 @@
 ;;; Support for resizable windows
 
 (defmethod kit.sdl2:window-event :before ((instance sketch-window) (type (eql :size-changed)) timestamp data1 data2)
-  (with-slots (sketch) instance
+  (with-slots ((sketch %sketch)) instance
     (with-slots ((env %env) width height y-axis) sketch
       (setf width data1
             height data2)


### PR DESCRIPTION
An attempt to fix the first render being lost due to window resizing (see: https://github.com/vydd/sketch/issues/69).

This is achieved by creating a separate `sketch-window` class so that `sketch` doesn't have to inherit from `gl-window`. That way, the slots of `sketch` can be initialized BEFORE the window gets created, and the window can be assigned the correct dimensions from the start, avoiding a resize.

Implementation notes:

* Since there may be a circular dependency between the sketch slots and the SDL2 window (specifically: trying to create textures during slot initialization would break because the OpenGL context of the window is not available yet), we have to delay their initialization. My approach is to create a skeleton `image` object, save a lambda that will do the OpenGL parts of image creation and update the `image`object, and then call all the lambdas after the window has been created.
* For backward compatibility with sketches that handle input via the `kit.sdl2` methods, we have to forward those method calls to the `sketch` object.
* For some reason, the call to `(gl:clear-color 0.0 1.0 0.0 1.0)` in `initialize-gl` started taking effect after the refactoring, and the background colour of sketches with `(copy-pixels t)` suddenly became green if they didn't call `background` anywhere (they had a black background before - I'm not sure why!). So I just changed it to `(gl:clear-color 0.0 0.0 0.0 1.0)` for backward compatibility.

Various parts of the code, as well as debugging help, were contributed by @Gleefre :)