### PR TITLE
Extend `on-leave` and `on-enter` to sketch windows

### DIFF
--- a/src/controllers.lisp
+++ b/src/controllers.lisp
@@ -12,6 +12,7 @@
 
 (defparameter *buttons* (list :left nil :middle nil :right nil))
 (defparameter *current-entity* nil)
+(defparameter *current-sketch* nil)
 
 (defmethod on-click (instance x y))
 (defmethod on-middle-click (instance x y))
@@ -53,6 +54,13 @@
       (setf *current-entity* entity)
       (on-enter entity))
     (call-next-method)))
+
+(defmethod on-hover :around ((instance sketch) ix iy)
+  (unless (eql *current-sketch* instance)
+    (on-leave *current-sketch*)
+    (setf *current-sketch* instance)
+    (on-enter instance))
+  (call-next-method))
 
 (defmethod kit.sdl2:mousebutton-event ((instance sketch) state timestamp button x y)
   (let ((button (elt (list nil :left :middle :right) button))


### PR DESCRIPTION
I was toying around with `show-cursor` and `hide-cursor` from `cl-sdl2`, and found that running 2 different sketches with different settings for this led to them competing for control of cursor visibility. 

Presumably SDL2's choice to make these kinds of things global variables means that many other effects have the same issue. Extending `on-leave` and `on-enter` to sketch windows could allow tracking of which sketch has mouse-focus, to better filter when to call these methods.