### PR TITLE
 Fix restart-frames -- C

### DIFF
--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -30,7 +30,7 @@
 
 (defclass sketch ()
   ((%env :initform (make-env) :reader sketch-%env)
-   (%restart :initform *restart-frames*)
+   (%restart :initform 1)
    (%viewport-changed :initform t)
    (%entities :initform (make-hash-table) :accessor sketch-%entities)
    (%window :initform nil :accessor sketch-%window :initarg :window)
@@ -146,7 +146,7 @@
     ((instance sketch) added-slots discarded-slots property-list &rest initargs)
   (declare (ignore added-slots discarded-slots property-list))
   (apply #'prepare instance initargs)
-  (setf (slot-value instance '%restart) *restart-frames*)
+  (setf (slot-value instance '%restart) 1)
   (setf (slot-value instance '%entities) (make-hash-table)))
 
 ;;; Rendering

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -210,10 +210,16 @@
             ;; That happens on setup or when recovering from an error.
             (when %restart
               (setf %restart nil)
-              (gl-catch (rgb 1 1 0.3)
-                (start-draw)
-                (setup instance)
-                (end-draw)))
+              (start-draw)
+              (if (debug-mode-p)
+                  (progn
+                    ;; If we're in debug mode, we exit from it immediately,
+                    ;; so that the restarts are shown only once.
+                    (exit-debug-mode)
+                    (setup instance))
+                  (gl-catch (rgb 1 1 0.3)
+                    (setup instance)))
+              (end-draw))
             (cond
               ;; If %RESTART is T, an error occured during SETUP.
               ;; Don't try calling DRAW, show an error screen instead.


### PR DESCRIPTION
Set the `%restart` to 1 (or rather `%restart-frames` to 0) initially, and don't call `draw` when `%restart-frames > 0`. Instead, a saved error message is show.