### PR TITLE
 Fix restart-frames -- D

### DIFF
--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -30,7 +30,7 @@
 
 (defclass sketch ()
   ((%env :initform (make-env) :reader sketch-%env)
-   (%restart :initform *restart-frames*)
+   (%restart :initform 1)
    (%viewport-changed :initform t)
    (%entities :initform (make-hash-table) :accessor sketch-%entities)
    (%window :initform nil :accessor sketch-%window :initarg :window)
@@ -146,7 +146,7 @@
     ((instance sketch) added-slots discarded-slots property-list &rest initargs)
   (declare (ignore added-slots discarded-slots property-list))
   (apply #'prepare instance initargs)
-  (setf (slot-value instance '%restart) *restart-frames*)
+  (setf (slot-value instance '%restart) 1)
   (setf (slot-value instance '%entities) (make-hash-table)))
 
 ;;; Rendering


### PR DESCRIPTION
Set the `%restart` to 1 initially (and not to `*restart-frames* = 2`) so that `setup` is called before calling `draw` for the first time.

This doesn't change the fact that `draw` is called even when `%restart > 1`, which kinda seems buggy to me, as it makes it so that `setup` is called right *after* the first successful (finished without errors) call to `draw`.