### PR TITLE
Fix restart-frames -- E

### DIFF
--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -203,7 +203,8 @@
             (exit-debug-mode)
             (draw-sketch instance))
           (gl-catch (rgb 0.7 0 0)
-            (draw-sketch instance))))))
+            (when (= %restart 0)
+              (draw-sketch instance)))))))
 
 (defmethod kit.sdl2:render ((instance sketch))
   (kit.sdl2:render (sketch-%window instance)))


### PR DESCRIPTION
Doesn't draw anything before the restart is finished Trusting myself too much that I knew what I was doing when I added %restart some time ago. I _think_ it had to do with making drawing in setup more robust, where previously errors would only be represented as red screens with no text.