### PR TITLE
Rewrite error handling

### DIFF
--- a/src/controllers.lisp
+++ b/src/controllers.lisp
@@ -103,7 +103,8 @@
                                               state timestamp button x y)
   (with-slots (%env) (%sketch instance)
     (when (env-red-screen %env)
-      (setf (env-debug-key-pressed %env) t))))
+      (when (eq state :mousebuttonup)
+        (setf (env-debug-key-pressed %env) t)))))
 
 ;;; Keyboard
 

--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -75,14 +75,6 @@
     (gl:clear :color-buffer :depth-buffer)
     (gl:flush)))
 
-(defun debug-mode-p ()
-  (and (env-red-screen *env*)
-       (env-debug-key-pressed *env*)))
-
-(defun exit-debug-mode ()
-  (setf (env-red-screen *env*) nil
-        (env-debug-key-pressed *env*) nil))
-
 (defmacro with-environment (env &body body)
   `(let ((*env* ,env))
      ,@body))


### PR DESCRIPTION
Removes old utilities:
  DEBUG-MODE-P, EXIT-DEBUG-MODE,
  %RESTART slot, \*RESTART-FRAMES\*,
  GL-CATCH, DRAW-SKETCH.

Adds
  %SETUP-CALLED slot,
  WITH-GL-DRAW, MAYBE-CHANGE-VIEWPORT,
  ON-ERROR generic function (can be exported for the user to extend).

* DEBUG-KEY-PRESSED is set only for :MOUSEBUTTONUP events, so that from one click restarts are shown only once.
* ON-ERROR is called after unwinding the stack when the debug key is not pressed. It accepts three parameters: the sketch instance, a keyword that indicates where an error occured (:SETUP or :DRAW), and the error object. The default method draws a red screen and sets (ENV-RED-SCREEN \*ENV\*) to T.
* If debug key is pressed, restarts are shown. A :RED-SCREEN restart is established, which calls ON-ERROR as if the debug key was not pressed.