### PR TITLE
Makes the winding rule configurable with pens

### DIFF
--- a/src/geometry.lisp
+++ b/src/geometry.lisp
@@ -71,9 +71,9 @@
 (defun triangulate (polygon)
   (let ((points (group polygon)))
     (apply #'append
-           (glu-tessellate:tessellate (make-array (length points)
-                                                  :initial-contents points)
-                                      :winding-rule :positive))))
+           (glu-tessellate:tessellate
+            (make-array (length points) :initial-contents points)
+            :winding-rule (pen-winding-rule (env-pen *env*))))))
 
 (defun bounding-box (vertices)
   (loop for (x y) in vertices

--- a/src/pen.lisp
+++ b/src/pen.lisp
@@ -12,7 +12,9 @@
   (fill nil)
   (stroke nil)
   (weight 1)
-  (curve-steps 100))
+  (curve-steps 100)
+  (winding-rule :nonzero
+   :type (member :odd :nonzero :positive :negative :abs-geq-two)))
 
 (defmacro with-pen (pen &body body)
   (with-shorthand (pen make-pen)
@@ -33,7 +35,8 @@
             :stroke (pen-fill pen)
             :fill (pen-stroke pen)
             :weight (pen-weight pen)
-            :curve-steps (pen-curve-steps pen)))
+            :curve-steps (pen-curve-steps pen)
+            :winding-rule (pen-winding-rule pen)))
 
 (defun background (color)
   "Fills the sketch window with COLOR."


### PR DESCRIPTION
Sets the default rule to :nonzero for backwards compatibility (setting it to :positive by default was a mistake).