### PR TITLE
Add new join methods for when polyline angles are too sharp.

### DIFF
--- a/src/geometry.lisp
+++ b/src/geometry.lisp
@@ -90,3 +90,40 @@
                 (list (normalize (first vertex) x1 x2)
                       (normalize (second vertex) y1 y2)))
               vertices))))
+
+(defun angle-between-lines (l1 l2)
+  "Calculate angle between 2 lines in positive radians. Doesn't handle
+lines of length 0. Lines are lists of 2 points; points are lists of 2 coordinates."
+  (let ((v1 (line-as-vector l1))
+        (v2 (line-as-vector l2)))
+    (acos (/ (dot-product v1 v2)
+             (vector-length v1)
+             (vector-length v2)))))
+
+(defun dot-product (v1 v2)
+  (+ (* (first v1) (first v2))
+     (* (second v1) (second v2))))
+
+(defun interior-angle-between-lines (l1 l2)
+  "Calculate interior angle between 2 lines, in positive radians."
+  (angle-between-lines
+   l1
+   (if (< 0 (dot-product (line-as-vector l1) (line-as-vector l2)))
+       l2
+       (reverse-line l2))))
+
+(defun reverse-line (line)
+  (destructuring-bind ((x1 y1) (x2 y2)) line
+    (let ((dx (- x2 x1))
+          (dy (- y2 y1)))
+      (list (first line)
+            (list (- x1 dx) (- y1 dy))))))
+
+(defun vector-length (v)
+  (destructuring-bind (x y) v
+    (sqrt (+ (* x x) (* y y)))))
+
+(defun line-as-vector (line)
+  "Takes a line (list of 2 points) and returns the vector connecting those points."
+  (destructuring-bind ((x1 y1) (x2 y2)) line
+    (list (- x2 x1) (- y2 y1))))

--- a/src/geometry.lisp
+++ b/src/geometry.lisp
@@ -96,9 +96,12 @@
 lines of length 0. Lines are lists of 2 points; points are lists of 2 coordinates."
   (let ((v1 (line-as-vector l1))
         (v2 (line-as-vector l2)))
-    (acos (/ (dot-product v1 v2)
-             (vector-length v1)
-             (vector-length v2)))))
+    ;; Ensure that input to acos is in range [-1,1].
+    (acos (max -1
+               (min 1
+                    (/ (dot-product v1 v2)
+                       (vector-length v1)
+                       (vector-length v2)))))))
 
 (defun dot-product (v1 v2)
   (+ (* (first v1) (first v2))

--- a/src/shapes.lisp
+++ b/src/shapes.lisp
@@ -97,21 +97,17 @@ or look ugly, and should be swapped for another join algorithm.")
   (if (let ((v1 (line-as-vector l1))
             (v2 (line-as-vector l2)))
         ;; Convert to coordinate system where v1 points along
-        ;; the positive x-axis. Then, if v2 is above the x-axis, it turns
-        ;; left relative to v1 and the left side of the polyline is interior
-        ;; here. Thus, we intersect the left side and bevel the right side.
-        ;; And vice versa.
+        ;; the positive x-axis. Then, if v2 is above the x-axis, we're at a
+        ;; left turn, and the left side of the line is interior.
+        ;; Thus, we intersect the left side and bevel the right side.
         (< 0 (+ (* (second v1) (first v2))
                 (* (- (first v1)) (second v2)))))
-      (values (duplicate
+      (values (duplicate-list
                (list (intersect-lines l1-left l2-left)))
               (list (second l1-right) (first l2-right)))
       (values (list (second l1-left) (first l2-left))
-              (duplicate
+              (duplicate-list
                (list (intersect-lines l1-right l2-right))))))
-
-(defun duplicate (list)
-  (append list list))
 
 (defun polyline (&rest coordinates)
   (case (pen-weight (env-pen *env*))

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -103,3 +103,6 @@ but may be considered unique for all practical purposes."
                  (cons ',maker ,var)
                  ,var)))
      ,@body))
+
+(defun duplicate-list (list)
+  (append list list))


### PR DESCRIPTION
Attempting to fix the polyline bug, see: https://github.com/vydd/sketch/issues/53

Visual artifacts were appearing for polylines with sharp corners. This is a known problem when using the miter method of joining 2 lines. The join points are calculated by extending the left and right sides of the lines until they intersect. If there's a small angle between the lines, however, the intersection points go to infinity and beyond (they're almost parallel), creating visual artifacts.

The solution implemented here is to switch to a different join method when there's a small angle between the lines. I arbitrarily chose a cutoff of 20 degrees to switch from meter join to bevel join. I find that the transition from miter to bevel is too jarring if the cutoff angle is smaller than that, but I'm open to changing it. I also added a cutoff of 2 degrees to switch from the bevel method to a "simple" join, because bevel also gets buggy when the lines are parallel-ish.

In the future, we could make the cutoff angles configurable. It would also be possible to allow the user the choose the join they want, and add more joins like `rounded`.

Will share some of the experimenting I've done to confirm the fix.