### PR TITLE
Make defsketch generate a function for running sketches.

### DIFF
--- a/README.org
+++ b/README.org
@@ -88,13 +88,14 @@ If you did everything correctly, you should be able to =(ql:quickload :sketch)= 
 
 #+BEGIN_SRC lisp
 CL-USER> (ql:quickload :sketch-examples)
-CL-USER> (make-instance 'sketch-examples:hello-world)
-CL-USER> (make-instance 'sketch-examples:sinewave)
-CL-USER> (make-instance 'sketch-examples:brownian)
-CL-USER> (make-instance 'sketch-examples:life) ; Click to toggle cells,
-                                               ; any key to toggle iteration
-CL-USER> (make-instance 'sketch-examples:input)
-CL-USER> (make-instance 'sketch-examples:stars)
+CL-USER> (in-package sketch-examples)
+SKETCH-EXAMPLES> (run-hello-world)
+SKETCH-EXAMPLES> (run-sinewave)
+SKETCH-EXAMPLES> (run-brownian)
+SKETCH-EXAMPLES> (run-life) ; Click to toggle cells,
+                            ; any key to toggle iteration
+SKETCH-EXAMPLES> (run-input)
+SKETCH-EXAMPLES> (run-stars)
 #+END_SRC
 
 *** Running example code from this page
@@ -108,11 +109,11 @@ TUTORIAL> ;; ready
 #+END_SRC
 
 ** Tutorial
-Defining sketches is done with the =defsketch= macro, which is essentially a wrapper for =defclass=.
+Defining sketches is done with the =defsketch= macro. This defines a function called `run-NAMEHERE` for starting your sketch.
 
 #+BEGIN_SRC lisp
   (defsketch tutorial ())
-  (make-instance 'tutorial)
+  (run-tutorial)
 #+END_SRC
 
 If all goes well, this should give you an unremarkable gray window. From now on, assuming you're using Emacs + SLIME, or a similarly capable environment, you can just re-evaluate =(defsketch tutorial () <insert drawing code here>)= and the sketch will be restarted without you having to close the window or make another instance of the class.

--- a/src/sketch.lisp
+++ b/src/sketch.lisp
@@ -315,6 +315,15 @@
                    collect `(,(binding-accessor b) *sketch*)
                    collect (binding-name b)))))
 
+(defun define-sketch-run-function (name bindings)
+  `(defun ,(alexandria:symbolicate 'run- name)
+       (&rest args
+          &key ,@(loop for b in bindings
+                        collect (list (binding-name b) (binding-initform b)))
+        &allow-other-keys)
+     (declare (ignore ,@(loop for b in bindings collect (binding-name b))))
+     (apply #'make-instance ',name args)))
+
 (defmacro defsketch (sketch-name binding-forms &body body)
   (let ((bindings (parse-bindings sketch-name binding-forms
                                   (class-bindings (find-class 'sketch)))))
@@ -323,6 +332,7 @@
        ,@(define-sketch-channel-observers bindings)
        ,(define-sketch-prepare-method sketch-name bindings)
        ,(define-sketch-draw-method sketch-name bindings body)
+       ,(define-sketch-run-function sketch-name bindings)
 
        (make-instances-obsolete ',sketch-name)
        (find-class ',sketch-name))))


### PR DESCRIPTION
This provides better abstraction for sketches, as the CLOS details of their implementation don't leak as much.

I also considered not generating a new run function for each sketch, but something like `(run-sketch 'blah)` would lead to a worse development experience because the expected arguments wouldn't show up in Emacs.

#### Testing
I ran some of the example sketches, they still work. Also:

```lisp
> (defsketch blah ()
     (circle 10 10 10))
> (run-blah :title "Testing!")
> (macroexpand-1
   '(defsketch blah ()
     (circle 10 10 10))
(PROGN
 (DEFCLASS BLAH (SKETCH) NIL)
 (DEFMETHOD PREPARE
            ((*SKETCH* BLAH)
             &KEY ((:TITLE TITLE) (SKETCH-TITLE *SKETCH*))
             ((:WIDTH WIDTH) (SKETCH-WIDTH *SKETCH*))
             ((:HEIGHT HEIGHT) (SKETCH-HEIGHT *SKETCH*))
             ((:FULLSCREEN FULLSCREEN) (SKETCH-FULLSCREEN *SKETCH*))
             ((:RESIZABLE RESIZABLE) (SKETCH-RESIZABLE *SKETCH*))
             ((:COPY-PIXELS COPY-PIXELS) (SKETCH-COPY-PIXELS *SKETCH*))
             ((:Y-AXIS Y-AXIS) (SKETCH-Y-AXIS *SKETCH*))
             ((:CLOSE-ON CLOSE-ON) (SKETCH-CLOSE-ON *SKETCH*))
             &ALLOW-OTHER-KEYS)
   (SETF (SKETCH-TITLE *SKETCH*) TITLE
         (SKETCH-WIDTH *SKETCH*) WIDTH
         (SKETCH-HEIGHT *SKETCH*) HEIGHT
         (SKETCH-FULLSCREEN *SKETCH*) FULLSCREEN
         (SKETCH-RESIZABLE *SKETCH*) RESIZABLE
         (SKETCH-COPY-PIXELS *SKETCH*) COPY-PIXELS
         (SKETCH-Y-AXIS *SKETCH*) Y-AXIS
         (SKETCH-CLOSE-ON *SKETCH*) CLOSE-ON))
 (DEFMETHOD DRAW ((*SKETCH* BLAH) &KEY X Y WIDTH HEIGHT MODE &ALLOW-OTHER-KEYS)
   (DECLARE (IGNORE X Y WIDTH HEIGHT MODE))
   (WITH-ACCESSORS ((TITLE SKETCH-TITLE) (WIDTH SKETCH-WIDTH)
                    (HEIGHT SKETCH-HEIGHT) (FULLSCREEN SKETCH-FULLSCREEN)
                    (RESIZABLE SKETCH-RESIZABLE)
                    (COPY-PIXELS SKETCH-COPY-PIXELS) (Y-AXIS SKETCH-Y-AXIS)
                    (CLOSE-ON SKETCH-CLOSE-ON))
       *SKETCH*
     (CIRCLE 10 10 10)))
 (DEFUN RUN-BLAH
        (
         &REST ARGS
         &KEY (TITLE "Sketch") (WIDTH *DEFAULT-WIDTH*)
         (HEIGHT *DEFAULT-HEIGHT*) (FULLSCREEN NIL) (RESIZABLE NIL)
         (COPY-PIXELS NIL) (Y-AXIS :DOWN) (CLOSE-ON :ESCAPE) &ALLOW-OTHER-KEYS)
   (DECLARE
    (IGNORE TITLE WIDTH HEIGHT FULLSCREEN RESIZABLE COPY-PIXELS Y-AXIS
     CLOSE-ON))
   (APPLY #'MAKE-INSTANCE 'BLAH ARGS))
 (MAKE-INSTANCES-OBSOLETE 'BLAH)
 (FIND-CLASS 'BLAH))
```