### PR TITLE
Batch vertices for large shapes.

### DIFF
--- a/src/geometry.lisp
+++ b/src/geometry.lisp
@@ -75,18 +75,21 @@
             (make-array (length points) :initial-contents points)
             :winding-rule (pen-winding-rule (env-pen *env*))))))
 
-(defun bounding-box (vertices)
-  (loop for (x y) in vertices
+(defun bounding-box (vertices &optional num-vertices)
+  (loop for j from 0
+        while (or (null num-vertices) (< j num-vertices))
+        for (x y) in vertices
         minimize x into min-x
         maximize x into max-x
         minimize y into min-y
         maximize y into max-y
         finally (return (list (list min-x min-y) (list max-x max-y)))))
 
-(defun normalize-to-bounding-box (vertices)
-  (let ((box (bounding-box vertices)))
+(defun normalize-to-bounding-box (vertices &optional num-vertices)
+  (let ((box (bounding-box vertices num-vertices)))
     (with-lines (box)
-      (mapcar (lambda (vertex)
-                (list (normalize (first vertex) x1 x2)
-                      (normalize (second vertex) y1 y2)))
-              vertices))))
+      (loop for j from 0
+            while (or (null num-vertices) (< j num-vertices))
+            for vertex in vertices
+            collect (list (normalize (first vertex) x1 x2)
+                          (normalize (second vertex) y1 y2))))))


### PR DESCRIPTION
Fix for this bug: https://github.com/vydd/sketch/issues/160

The draw buffer isn't large enough for shapes that consist of more than about 6000 vertices, so we need to batch the draw calls. Different batching behaviour is required for different primitive types, e.g. for triangle strips, in each batch you have to include the last 2 vertices from the previous batch so that the strip is continuous. I've only covered the `:triangles` and `:triangle-strip` primitive types.

#### Testing
This triggers the batching for `:triangles`. It's basically the example case that Gleefre gave with the bug report, and crashes without batching.

```lisp
(defsketch huge-polygon ()
    (with-pen (make-pen :fill +white+ :stroke +black+ :weight 2)
      (apply #'polygon (loop repeat 300 collect (random 400))))
    (stop-loop))
```

Here's how the batching logic works for `:triangles`. `batch-vertices` returns a list of batches: each batch consists of the number of vertices in that batch, a pointer to the start of that batch in the list of all vertices, and a boolean indicating whether it's the last batch. I took this approach, rather than returning new lists of vertices, to avoid excessive cons-ing.

```lisp
(let ((*buffer-size* (* 5 *bytes-per-vertex*)))
          (with-environment (make-env)
            (batch-vertices '(1 2 3 4 5 6 7 8 9) :triangles)))
((3 (1 2 3 4 5 6 7 8 9) NIL) (3 (4 5 6 7 8 9) NIL) (3 (7 8 9) T))
(let ((*buffer-size* (* 6 *bytes-per-vertex*)))
          (with-environment (make-env)
            (batch-vertices '(1 2 3 4 5 6 7 8 9) :triangles)))
((6 (1 2 3 4 5 6 7 8 9) NIL) (3 (7 8 9) T))
```

This triggers the `:triangle-strip` batching.

```lisp
(defsketch huge-polyline ()
    (with-pen (make-pen :stroke +white+ :weight 2)
      (apply #'polyline (loop repeat 10000 collect (random 400))))
    (stop-loop))
```

And here's the corresponding batching logic. Recall that each batch must contain the last 2 vertices from the previous batch.

```lisp
SKETCH> (let ((*buffer-size* (* 5 *bytes-per-vertex*)))
          (with-environment (make-env)
            (batch-vertices '(1 2 3 4 5) :triangle-strip)))
((5 (1 2 3 4 5) T))
SKETCH> (let ((*buffer-size* (* 5 *bytes-per-vertex*)))
          (with-environment (make-env)
            (batch-vertices '(1 2 3 4 5 6) :triangle-strip)))
((5 (1 2 3 4 5 6) NIL) (3 (4 5 6) T))
SKETCH> (let ((*buffer-size* (* 5 *bytes-per-vertex*)))
          (with-environment (make-env)
            (batch-vertices '(1 2 3 4 5 6 7 8 9 10) :triangle-strip)))
((5 (1 2 3 4 5 6 7 8 9 10) NIL) (5 (4 5 6 7 8 9 10) NIL) (4 (7 8 9 10) T))
```


One thing that's not addressed: I think the texture might be discontinuous on a polygon whose constituent triangles are batched. Perhaps that could be fixed by calculating the bounding box once for all the vertices, rather than once per batch? I'm not sure how textures are mapped onto triangles, however, so I'm not sure.