### PR TITLE
Add extensible environment system

### DIFF
--- a/src/environment.lisp
+++ b/src/environment.lisp
@@ -10,7 +10,6 @@
 
 (defstruct env
   ;; Drawing
-  (pen nil)
   (programs nil)
   (model-matrix (sb-cga:identity-matrix)) ; TODO: sb-cga shouldn't be used directly from here
   (view-matrix nil)
@@ -105,7 +104,6 @@ Then use: (env-my-cache *env*)"
           (env-vao env) (make-instance 'kit.gl.vao:vao :type 'sketch-vao)
           (env-white-pixel-texture env) (make-white-pixel-texture)
           (env-white-color-vector env) #(255 255 255 255)
-          (env-pen env) (make-default-pen)
           (env-font env) (make-default-font))
     (initialize-view-matrix sketch)
     (initialize-environment-extensions env)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -212,4 +212,8 @@
            :noise
            :noise-seed
            :noise-detail
+
+           ;; Environment extension
+           :define-environment-property
+           :*env*
            ))

--- a/src/pen.lisp
+++ b/src/pen.lisp
@@ -16,6 +16,12 @@
   (winding-rule :nonzero
    :type (member :odd :nonzero :positive :negative :abs-geq-two)))
 
+(defun make-default-pen ()
+  (make-pen :weight 1 :fill +white+ :stroke +black+))
+
+(define-environment-property :pen
+  (make-default-pen))
+
 (defmacro with-pen (pen &body body)
   (with-shorthand (pen make-pen)
     (alexandria:with-gensyms (previous-pen)
@@ -42,10 +48,3 @@
   "Fills the sketch window with COLOR."
   (apply #'gl:clear-color (color-rgba color))
   (gl:clear :color-buffer))
-
-(let ((pen))
-  (defun make-default-pen ()
-    (setf pen (or pen
-                  (make-pen :weight 1
-                            :fill +white+
-                            :stroke +black+)))))


### PR DESCRIPTION
## Summary
- Add infrastructure for defining environment properties outside environment.lisp
- Includes workaround for noisy library export issue (first commit)

## Changes

### Extensible Environment
- `env` struct gains `extensions` hash-table for dynamic properties
- `define-environment-property` macro generates accessors/setters automatically
- Properties initialized via `initialize-environment-extensions` during env setup
- New exports: `define-environment-property`, `*env*`

### Example Usage
```lisp
(define-environment-property :my-cache
  (make-hash-table))

;; Then use:
(env-my-cache *env*)
(setf (env-my-cache *env*) new-value)
```

## Why
This enables future refactoring where properties like `:pen`, `:font` can be moved to their respective files while maintaining backward compatibility. It's the first step toward a cleaner backend separation (see PR #162).

## Test plan
- [x] Sketch loads successfully
- [x] New properties can be defined and accessed
- [x] Existing functionality unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)